### PR TITLE
Make some ctors implicit

### DIFF
--- a/include/ddc/detail/tagged_vector.hpp
+++ b/include/ddc/detail/tagged_vector.hpp
@@ -242,8 +242,7 @@ public:
     inline constexpr TaggedVector(TaggedVector&&) = default;
 
     template <class... OTags>
-    explicit inline constexpr TaggedVector(
-            TaggedVector<ElementType, OTags> const&... other) noexcept
+    inline constexpr TaggedVector(TaggedVector<ElementType, OTags> const&... other) noexcept
         : m_values {take<Tags>(other...).value()...}
     {
     }


### PR DESCRIPTION
it's nice to be able to use `{vx,vy}` where a `vxy` is expected and I don't see any danger with it