### PR TITLE
Implement a store to keep track of dynamic allocations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         android: true
         dotnet: true
         haskell: true
-        large-packages: true
+        large-packages: false
         swap-storage: true
     - name: Checkout built branch
       uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,18 @@ jobs:
   docker-build-test_env:
     runs-on: ubuntu-latest
     steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+
+        # all of these default to true, but feel free to set to
+        # "false" if necessary for your workflow
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        swap-storage: true
     - name: Checkout built branch
       uses: actions/checkout@v3
     - name: Build

--- a/include/ddc/discrete_space.hpp
+++ b/include/ddc/discrete_space.hpp
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <any>
+#include <map>
+#include <memory>
 #include <ostream>
 #include <stdexcept>
 

--- a/include/ddc/dual_discretization.hpp
+++ b/include/ddc/dual_discretization.hpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <Kokkos_Core.hpp>
+
+#include "ddc/detail/macros.hpp"
+
+#if defined(__CUDACC__)
+#include <cuda.h>
+#endif
+#if defined(__HIPCC__)
+#include <hip/hip_runtime.h>
+#endif
+
+template <class DDim>
+class DualDiscretization
+{
+    using DDimImplHost = typename DDim::template Impl<Kokkos::HostSpace>;
+#if defined(__CUDACC__)
+    using DDimImplDevice = typename DDim::template Impl<Kokkos::CudaSpace>;
+#elif defined(__HIPCC__)
+    using DDimImplDevice = typename DDim::template Impl<Kokkos::Experimental::HIPSpace>;
+#endif
+
+    DDimImplHost m_host;
+#if defined(__CUDACC__) || defined(__HIPCC__)
+    DDimImplDevice m_device_on_host;
+    std::unique_ptr<DDimImplDevice, std::function<void(DDimImplDevice*)>> m_device;
+#endif
+
+public:
+    template <class... Args>
+    explicit DualDiscretization(Args&&... args)
+        : m_host(std::forward<Args>(args)...)
+#if defined(__CUDACC__) || defined(__HIPCC__)
+        , m_device_on_host(m_host)
+#endif
+    {
+#if defined(__CUDACC__)
+        DDimImplDevice* ptr_device;
+        cudaMalloc(&ptr_device, sizeof(DDimImplDevice));
+        m_device = std::unique_ptr<
+                DDimImplDevice,
+                std::function<void(DDimImplDevice*)>>(ptr_device, [](DDimImplDevice* ptr) {
+            cudaFree(ptr);
+        });
+        cudaMemcpy(
+                reinterpret_cast<void*>(ptr_device),
+                &m_device_on_host,
+                sizeof(DDimImplDevice),
+                cudaMemcpyHostToDevice);
+#elif defined(__HIPCC__)
+        DDimImplDevice* ptr_device;
+        hipMalloc(&ptr_device, sizeof(DDimImplDevice));
+        m_device = std::unique_ptr<
+                DDimImplDevice,
+                std::function<void(DDimDDimImplDevice*)>>(ptr_device, [](DDimImplDevice* ptr) {
+            hipFree(ptr);
+        });
+        hipMemcpy(
+                reinterpret_cast<void*>(ptr_device),
+                &m_device_on_host,
+                sizeof(DDimImplDevice),
+                hipMemcpyHostToDevice);
+#endif
+    }
+
+    template <class MemorySpace>
+    DDC_INLINE_FUNCTION typename DDim::template Impl<MemorySpace> const& get()
+    {
+        if constexpr (std::is_same_v<MemorySpace, Kokkos::HostSpace>) {
+            return m_host;
+        }
+#if defined(__CUDACC__)
+        else if constexpr (std::is_same_v<MemorySpace, Kokkos::CudaSpace>) {
+            return m_device_on_host;
+        }
+#elif defined(__CUDACC__)
+        else if constexpr (std::is_same_v<MemorySpace, Kokkos::Experimental::HIPSpace>) {
+            return m_device_on_host;
+        }
+#endif
+        else {
+            static_assert(!std::is_same_v<MemorySpace, MemorySpace>);
+        }
+    }
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+    DDimImplDevice* get_device_ptr() const
+    {
+        return m_device.get();
+    }
+#endif
+};

--- a/include/ddc/dual_discretization.hpp
+++ b/include/ddc/dual_discretization.hpp
@@ -60,7 +60,7 @@ public:
         hipMalloc(&ptr_device, sizeof(DDimImplDevice));
         m_device = std::unique_ptr<
                 DDimImplDevice,
-                std::function<void(DDimDDimImplDevice*)>>(ptr_device, [](DDimImplDevice* ptr) {
+                std::function<void(DDimImplDevice*)>>(ptr_device, [](DDimImplDevice* ptr) {
             hipFree(ptr);
         });
         hipMemcpy(

--- a/include/ddc/scope_guard.hpp
+++ b/include/ddc/scope_guard.hpp
@@ -35,8 +35,8 @@ public:
 
     ~ScopeGuard() noexcept
     {
-        for (auto const& f : *detail::g_discretization_store) {
-            f.second();
+        for (auto const& [name, fn] : *detail::g_discretization_store) {
+            fn();
         }
         detail::g_discretization_store.reset();
     }

--- a/include/ddc/scope_guard.hpp
+++ b/include/ddc/scope_guard.hpp
@@ -35,6 +35,9 @@ public:
 
     ~ScopeGuard() noexcept
     {
+        for (auto const& f : *detail::g_discretization_store) {
+            f.second();
+        }
         detail::g_discretization_store.reset();
     }
 

--- a/include/ddc/scope_guard.hpp
+++ b/include/ddc/scope_guard.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <map>
+#include <memory>
+
 #include <Kokkos_Core.hpp>
 
 #include "discrete_space.hpp"

--- a/include/ddc/scope_guard.hpp
+++ b/include/ddc/scope_guard.hpp
@@ -8,10 +8,7 @@ class ScopeGuard
 {
     Kokkos::ScopeGuard m_kokkos_scope_guard;
 
-public:
-    ScopeGuard() = default;
-
-    ScopeGuard(int argc, char**& argv) : m_kokkos_scope_guard(argc, argv)
+    void discretization_store_initialization() const
     {
         detail::g_host_discretization_store = std::make_unique<std::map<std::string, std::any>>();
 #if defined(__CUDACC__)
@@ -19,6 +16,17 @@ public:
 #elif defined(__HIPCC__)
         detail::g_hip_discretization_store = std::make_unique<std::map<std::string, void*>>();
 #endif
+    }
+
+public:
+    ScopeGuard()
+    {
+        discretization_store_initialization();
+    }
+
+    ScopeGuard(int argc, char**& argv) : m_kokkos_scope_guard(argc, argv)
+    {
+        discretization_store_initialization();
     }
 
     ScopeGuard(ScopeGuard const& x) = delete;

--- a/include/ddc/scope_guard.hpp
+++ b/include/ddc/scope_guard.hpp
@@ -2,6 +2,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include "discrete_space.hpp"
+
 class ScopeGuard
 {
     Kokkos::ScopeGuard m_kokkos_scope_guard;
@@ -9,13 +11,35 @@ class ScopeGuard
 public:
     ScopeGuard() = default;
 
-    ScopeGuard(int argc, char**& argv) : m_kokkos_scope_guard(argc, argv) {}
+    ScopeGuard(int argc, char**& argv) : m_kokkos_scope_guard(argc, argv)
+    {
+        detail::g_host_discretization_store = std::make_unique<std::map<std::string, std::any>>();
+#if defined(__CUDACC__)
+        detail::g_cuda_discretization_store = std::make_unique<std::map<std::string, void*>>();
+#elif defined(__HIPCC__)
+        detail::g_hip_discretization_store = std::make_unique<std::map<std::string, void*>>();
+#endif
+    }
 
     ScopeGuard(ScopeGuard const& x) = delete;
 
     ScopeGuard(ScopeGuard&& x) noexcept = delete;
 
-    ~ScopeGuard() noexcept = default;
+    ~ScopeGuard() noexcept
+    {
+        detail::g_host_discretization_store = nullptr;
+#if defined(__CUDACC__)
+        for (auto const& [key, value] : *detail::g_cuda_discretization_store) {
+            cudaFree(value);
+        }
+        detail::g_cuda_discretization_store = nullptr;
+#elif defined(__HIPCC__)
+        for (auto const& [key, value] : *detail::g_hip_discretization_store) {
+            hipFree(value);
+        }
+        detail::g_hip_discretization_store = nullptr;
+#endif
+    }
 
     ScopeGuard& operator=(ScopeGuard const& x) = delete;
 


### PR DESCRIPTION
The idea is to keep record of allocations using type erasure when necessary. All deallocations happen at the destruction of the ddc scope guard, before the destruction of the Kokkos scope guard.