### PR TITLE
Remove line raising unused warning

### DIFF
--- a/include/ddc/uniform_point_sampling.hpp
+++ b/include/ddc/uniform_point_sampling.hpp
@@ -174,7 +174,6 @@ public:
             discrete_vector_type n_ghosts_before,
             discrete_vector_type n_ghosts_after)
     {
-        using continuous_element_type = continuous_element_type;
         using discrete_domain_type = discrete_domain_type;
         assert(a < b);
         assert(n > 1);


### PR DESCRIPTION
`uniform_point_sampling.hpp` is raising the following warning:
```
/home/emily/Code/VOICE/voicexx/vendor/ddc/include/ddc/uniform_point_sampling.hpp: In static member function ‘static std::tuple<ddc::UniformPointSampling<CDim>::Impl<Kokkos::HostSpace>, ddc::DiscreteDomain<ddc::UniformPointSampling<CDim> >, ddc::DiscreteDomain<ddc::UniformPointSampling<CDim> >, ddc::DiscreteDomain<ddc::UniformPointSampling<CDim> >, ddc::DiscreteDomain<ddc::UniformPointSampling<CDim> > > ddc::UniformPointSampling<CDim>::init_ghosted(ddc::UniformPointSampling<CDim>::continuous_element_type, ddc::UniformPointSampling<CDim>::continuous_element_type, ddc::UniformPointSampling<CDim>::discrete_vector_type, ddc::UniformPointSampling<CDim>::discrete_vector_type, ddc::UniformPointSampling<CDim>::discrete_vector_type)’:
/home/emily/Code/VOICE/voicexx/vendor/ddc/include/ddc/uniform_point_sampling.hpp:177:15: warning: typedef ‘using continuous_element_type = using continuous_element_type = ddc::Coordinate<CDim>’ locally defined but not used [-Wunused-local-typedefs]
  177 |         using continuous_element_type = continuous_element_type;
```
This PR removes the offending line