### PR TITLE
kokkos::finalize() when sigint

### DIFF
--- a/include/ddc/scope_guard.hpp
+++ b/include/ddc/scope_guard.hpp
@@ -5,6 +5,7 @@
 #include <optional>
 
 #include <Kokkos_Core.hpp>
+#include <signal.h>
 
 #include "discrete_space.hpp"
 
@@ -19,6 +20,14 @@ class ScopeGuard
         detail::g_discretization_store
                 = std::make_optional<std::map<std::string, std::function<void()>>>();
     }
+    static void sigintHandler(int signum)
+    {
+        if (Kokkos::is_initialized()) {
+            Kokkos::finalize();
+        }
+        signal(SIGINT, SIG_DFL);
+        raise(SIGINT);
+    }
 
 public:
     ScopeGuard()
@@ -29,6 +38,7 @@ public:
     ScopeGuard(int argc, char**& argv) : m_kokkos_scope_guard(argc, argv)
     {
         discretization_store_initialization();
+        signal(SIGINT, sigintHandler);
     }
 
     ScopeGuard(ScopeGuard const& x) = delete;


### PR DESCRIPTION
Calls Kokkos::finalize() in ScopeGuard when SIGINT.

Purpose: Kokkos-Tools like https://github.com/kokkos/kokkos-tools/blob/develop/profiling/simple-kernel-timer/kp_kernel_timer.cpp may write profiling files when Kokkos is finalized. It is usefull to profile Gysela without reaching the end of the simulation.

(Maybe it could be proposed to Kokkos)