### PR TITLE
Use `StridedDiscreteDomain`s to pass the derivatives to the spline builders

### DIFF
--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -178,6 +178,13 @@ void characteristics_advection_unitary(benchmark::State& state)
             spline_builder.batched_interpolation_domain(x_mesh),
             ddc::KokkosAllocator<ddc::Coordinate<X>, typename ExecSpace::memory_space>());
     ddc::ChunkSpan const feet_coords = feet_coords_alloc.span_view();
+    ddc::ChunkSpan<
+            double const,
+            ddc::StridedDiscreteDomain<
+                    DDimX<IsNonUniform, s_degree_x>,
+                    ddc::Deriv<typename DDimX<IsNonUniform, s_degree_x>::continuous_dimension_type>,
+                    DDimY>>
+            derivs;
 
     for (auto _ : state) {
         Kokkos::Profiling::pushRegion("FeetCharacteristics");
@@ -193,7 +200,7 @@ void characteristics_advection_unitary(benchmark::State& state)
                 });
         Kokkos::Profiling::popRegion();
         Kokkos::Profiling::pushRegion("SplineBuilder");
-        spline_builder(coef, density.span_cview());
+        spline_builder(coef, density.span_cview(), derivs.span_cview());
         Kokkos::Profiling::popRegion();
         Kokkos::Profiling::pushRegion("SplineEvaluator");
         spline_evaluator(density, feet_coords.span_cview(), coef.span_cview());

--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -183,7 +183,9 @@ void characteristics_advection_unitary(benchmark::State& state)
             ddc::StridedDiscreteDomain<
                     DDimX<IsNonUniform, s_degree_x>,
                     ddc::Deriv<typename DDimX<IsNonUniform, s_degree_x>::continuous_dimension_type>,
-                    DDimY>> const derivs {};
+                    DDimY>,
+            Kokkos::layout_right,
+            typename ExecSpace::memory_space> const derivs {};
 
     for (auto _ : state) {
         Kokkos::Profiling::pushRegion("FeetCharacteristics");

--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -183,8 +183,7 @@ void characteristics_advection_unitary(benchmark::State& state)
             ddc::StridedDiscreteDomain<
                     DDimX<IsNonUniform, s_degree_x>,
                     ddc::Deriv<typename DDimX<IsNonUniform, s_degree_x>::continuous_dimension_type>,
-                    DDimY>>
-            derivs;
+                    DDimY>> const derivs {};
 
     for (auto _ : state) {
         Kokkos::Profiling::pushRegion("FeetCharacteristics");

--- a/examples/characteristics_advection.cpp
+++ b/examples/characteristics_advection.cpp
@@ -232,6 +232,11 @@ int main(int argc, char** argv)
     ddc::ChunkSpan const feet_coords = feet_coords_alloc.span_view();
     //! [instantiate intermediate chunks]
 
+    // FIXME: comment
+    ddc::ChunkSpan<
+            double const,
+            ddc::StridedDiscreteDomain<DDimX, ddc::Deriv<DDimX::continuous_dimension_type>, DDimY>>
+            derivs;
 
     //! [time iteration]
     for (auto const iter : time_domain.remove_first(ddc::DiscreteVector<DDimT>(1))) {
@@ -255,7 +260,7 @@ int main(int argc, char** argv)
                                      - ddc::Coordinate<X>(vx * ddc::step<DDimT>());
                 });
         // Interpolate the values at feet on the grid
-        spline_builder(coef, last_density.span_cview());
+        spline_builder(coef, last_density.span_cview(), derivs.span_cview());
         spline_evaluator(next_density, feet_coords.span_cview(), coef.span_cview());
         //! [numerical scheme]
 

--- a/examples/characteristics_advection.cpp
+++ b/examples/characteristics_advection.cpp
@@ -13,6 +13,7 @@
 #include <ddc/kernels/splines.hpp>
 
 #include <Kokkos_Core.hpp>
+#include <Kokkos_Core_fwd.hpp>
 
 #define PERIODIC_DOMAIN // Comment this to run non-periodic simulation
 
@@ -234,10 +235,9 @@ int main(int argc, char** argv)
     // Instantiate empty derivative chunkspan
     ddc::ChunkSpan<
             double const,
-            ddc::StridedDiscreteDomain<
-                    DDimX,
-                    ddc::Deriv<DDimX::continuous_dimension_type>,
-                    DDimY>> const derivs {};
+            ddc::StridedDiscreteDomain<DDimX, ddc::Deriv<DDimX::continuous_dimension_type>, DDimY>,
+            Kokkos::layout_right,
+            ddc::DeviceAllocator<double>::memory_space> const derivs {};
     //! [instantiate intermediate chunks]
 
 

--- a/examples/characteristics_advection.cpp
+++ b/examples/characteristics_advection.cpp
@@ -230,13 +230,16 @@ int main(int argc, char** argv)
             spline_builder.batched_interpolation_domain(x_mesh),
             ddc::DeviceAllocator<ddc::Coordinate<X>>());
     ddc::ChunkSpan const feet_coords = feet_coords_alloc.span_view();
-    //! [instantiate intermediate chunks]
 
-    // FIXME: comment
+    // Instantiate empty derivative chunkspan
     ddc::ChunkSpan<
             double const,
-            ddc::StridedDiscreteDomain<DDimX, ddc::Deriv<DDimX::continuous_dimension_type>, DDimY>>
-            derivs;
+            ddc::StridedDiscreteDomain<
+                    DDimX,
+                    ddc::Deriv<DDimX::continuous_dimension_type>,
+                    DDimY>> const derivs {};
+    //! [instantiate intermediate chunks]
+
 
     //! [time iteration]
     for (auto const iter : time_domain.remove_first(ddc::DiscreteVector<DDimT>(1))) {

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -964,7 +964,6 @@ operator()(
                 StridedLayout,
                 memory_space> const derivs) const
 {
-    using interpolation_sddom = ddc::StridedDiscreteDomain<interpolation_discrete_dimension_type>;
     auto const batched_interpolation_domain = vals.domain();
 
     assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -25,6 +25,27 @@
 
 namespace ddc {
 
+namespace detail {
+template <typename... DDims>
+struct make_discrete_vector
+{
+    template <std::size_t... Ints>
+    static ddc::DiscreteVector<DDims...> exec(std::index_sequence<Ints...>)
+    {
+        // Using the comma operator (Ints, 1)... gives an unused value warning
+        return ddc::DiscreteVector<DDims...>((Ints - Ints + 1)...);
+    }
+};
+template <typename... DDim>
+ddc::StridedDiscreteDomain<DDim...> to_strided_ddom(ddc::DiscreteDomain<DDim...> const& ddom)
+{
+    return ddc::StridedDiscreteDomain<DDim...>(
+            ddom.front(),
+            ddom.extents(),
+            make_discrete_vector<DDim...>::exec(std::make_index_sequence<sizeof...(DDim)> {}));
+}
+} // namespace detail
+
 /**
  * @brief An enum determining the backend solver of a SplineBuilder or SplineBuilder2d.
  *
@@ -153,6 +174,7 @@ private:
 
 public:
     /**
+     * TODO: update documentation
      * @brief The type of the whole Deriv domain (cartesian product of 1D Deriv domain
      * and batch domain) preserving the underlying memory layout (order of dimensions).
      *
@@ -164,10 +186,26 @@ public:
     template <
             class BatchedInterpolationDDom,
             class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
-    using batched_derivs_domain_type = ddc::replace_dim_of_t<
-            BatchedInterpolationDDom,
-            interpolation_discrete_dimension_type,
-            deriv_type>;
+    using whole_derivs_domain_type
+            = ddc::detail::convert_type_seq_to_strided_discrete_domain_t<ddc::type_seq_cat_t<
+                    ddc::detail::TypeSeq<deriv_type>,
+                    ddc::to_type_seq_t<BatchedInterpolationDDom>>>;
+
+    /**
+     * @brief The type of the whole Deriv domain (cartesian product of 1D Deriv domain
+     * and batch domain) preserving the underlying memory layout (order of dimensions).
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
+     * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and a dimension of interest Y,
+     * this is DiscreteDomain<X,Deriv<Y>,Z>
+     */
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using batched_derivs_domain_type = ddc::remove_dims_of_t<
+            whole_derivs_domain_type<BatchedInterpolationDDom>,
+            interpolation_discrete_dimension_type>;
 
     /// @brief Indicates if the degree of the splines is odd or even.
     static constexpr bool s_odd = BSplines::degree() % 2;
@@ -421,11 +459,13 @@ public:
             BatchedInterpolationDDom const& batched_interpolation_domain) const noexcept
     {
         assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
-        return ddc::replace_dim_of<interpolation_discrete_dimension_type, deriv_type>(
-                batched_interpolation_domain,
-                ddc::DiscreteDomain<deriv_type>(
-                        ddc::DiscreteElement<deriv_type>(1),
-                        ddc::DiscreteVector<deriv_type>(s_nbc_xmin)));
+        return ddc::StridedDiscreteDomain(
+                detail::to_strided_ddom(
+                        ddc::replace_dim_of<interpolation_discrete_dimension_type, deriv_type>(
+                                batched_interpolation_domain,
+                                ddc::DiscreteDomain<deriv_type>(
+                                        ddc::DiscreteElement<deriv_type>(1),
+                                        ddc::DiscreteVector<deriv_type>(s_nbc_xmin)))));
     }
 
     /**
@@ -442,11 +482,13 @@ public:
             BatchedInterpolationDDom const& batched_interpolation_domain) const noexcept
     {
         assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
-        return ddc::replace_dim_of<interpolation_discrete_dimension_type, deriv_type>(
-                batched_interpolation_domain,
-                ddc::DiscreteDomain<deriv_type>(
-                        ddc::DiscreteElement<deriv_type>(1),
-                        ddc::DiscreteVector<deriv_type>(s_nbc_xmax)));
+        return ddc::StridedDiscreteDomain(
+                detail::to_strided_ddom(
+                        ddc::replace_dim_of<interpolation_discrete_dimension_type, deriv_type>(
+                                batched_interpolation_domain,
+                                ddc::DiscreteDomain<deriv_type>(
+                                        ddc::DiscreteElement<deriv_type>(1),
+                                        ddc::DiscreteVector<deriv_type>(s_nbc_xmax)))));
     }
 
     /**
@@ -468,7 +510,7 @@ public:
      * @param[in] derivs_xmax The values of the derivatives at the upper boundary
      * (used only with BoundCond::HERMITE upper boundary condition).
      */
-    template <class Layout, class BatchedInterpolationDDom>
+    template <class Layout, class StridedLayout, class BatchedInterpolationDDom>
     void operator()(
             ddc::ChunkSpan<
                     double,
@@ -476,18 +518,11 @@ public:
                     Layout,
                     memory_space> spline,
             ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
-            std::optional<ddc::ChunkSpan<
+            ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> derivs_xmin
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> derivs_xmax
-            = std::nullopt) const;
+                    whole_derivs_domain_type<BatchedInterpolationDDom>,
+                    StridedLayout,
+                    memory_space> derivs) const;
 
     /**
      * @brief Compute the quadrature coefficients associated to the b-splines used by this SplineBuilder.
@@ -793,7 +828,7 @@ template <
         ddc::BoundCond BcLower,
         ddc::BoundCond BcUpper,
         SplineSolver Solver>
-template <class Layout, class BatchedInterpolationDDom>
+template <class Layout, class StridedLayout, class BatchedInterpolationDDom>
 void SplineBuilder<ExecSpace, MemorySpace, BSplines, InterpolationDDim, BcLower, BcUpper, Solver>::
 operator()(
         ddc::ChunkSpan<
@@ -802,17 +837,13 @@ operator()(
                 Layout,
                 memory_space> spline,
         ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
-        std::optional<ddc::ChunkSpan<
+        ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> const derivs_xmin,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> const derivs_xmax) const
+                whole_derivs_domain_type<BatchedInterpolationDDom>,
+                StridedLayout,
+                memory_space> const derivs) const
 {
+    using interpolation_sddom = ddc::StridedDiscreteDomain<interpolation_discrete_dimension_type>;
     auto const batched_interpolation_domain = vals.domain();
 
     assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
@@ -835,8 +866,10 @@ operator()(
     // NOTE: For consistency with the linear system, the i-th derivative
     //       provided by the user must be multiplied by dx^i
     if constexpr (BcLower == BoundCond::HERMITE) {
-        assert(derivs_xmin->template extent<deriv_type>() == s_nbc_xmin);
-        auto derivs_xmin_values = *derivs_xmin;
+        assert(derivs->template extent<deriv_type>() == s_nbc_xmin);
+        auto derivs_xmin_values
+                = derivs[ddc::DiscreteElement<interpolation_discrete_dimension_type>(
+                        derivs.domain().front())];
         auto const dx_proxy = m_dx;
         ddc::parallel_for_each(
                 "ddc_splines_hermite_compute_lower_coefficients",
@@ -880,8 +913,10 @@ operator()(
     //       provided by the user must be multiplied by dx^i
     auto const& nbasis_proxy = ddc::discrete_space<bsplines_type>().nbasis();
     if constexpr (BcUpper == BoundCond::HERMITE) {
-        assert(derivs_xmax->template extent<deriv_type>() == s_nbc_xmax);
-        auto derivs_xmax_values = *derivs_xmax;
+        assert(derivs->template extent<deriv_type>() == s_nbc_xmax);
+        auto derivs_xmax_values
+                = derivs[ddc::DiscreteElement<interpolation_discrete_dimension_type>(
+                        derivs.domain().back())];
         auto const dx_proxy = m_dx;
         ddc::parallel_for_each(
                 "ddc_splines_hermite_compute_upper_coefficients",

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -32,7 +32,7 @@ namespace detail {
 // TODO: move all these functions to another file
 
 /**
- * @brief Create a DiscreteVector with each component initalized to the same value.
+ * @brief Create a DiscreteVector with each component initialized to the same value.
  */
 template <typename... DDims, typename T>
 ddc::DiscreteVector<DDims...> make_discrete_vector(T const& value)
@@ -91,7 +91,7 @@ using to_whole_derivs_domain_t =
  *
  * @tparam DerivDims... The deriv dimensions which will replace the interpolation dimensions.
  * @param interpolation_dom The domain containing only the interpolation dimensions.
- * @param batched_domain The domain conatining both the interpolation and batch dimensions.
+ * @param batched_domain The domain containing both the interpolation and batch dimensions.
  * @param nb_constraints The number of constraints for each of the deriv dimensions.
  *
  * @return A StridedDiscreteDomain with the batch dimensions, the deriv dimensions and the strided interpolation dimensions.
@@ -295,7 +295,7 @@ private:
 public:
     /**
      * @brief The type of the whole Deriv domain (1D dimension of interest and cartesian
-     * product of 1D Deriv domain and batch domain) to be passed as argument to the buider,
+     * product of 1D Deriv domain and batch domain) to be passed as argument to the builder,
      * preserving the underlying memory layout (order of dimensions).
      *
      * @tparam The batched discrete domain on which the interpolation points are defined.

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -28,23 +28,18 @@
 namespace ddc {
 
 namespace detail {
-template <typename... DDims>
-struct make_discrete_vector
+
+template <typename... DDims, typename T>
+ddc::DiscreteVector<DDims...> make_discrete_vector(T const& value)
 {
-    template <std::size_t... Ints>
-    static ddc::DiscreteVector<DDims...> exec(std::index_sequence<Ints...>)
-    {
-        // Using the comma operator (Ints, 1)... gives an unused value warning
-        return ddc::DiscreteVector<DDims...>((Ints - Ints + 1)...);
-    }
-};
+    return ddc::DiscreteVector<DDims...>((ddc::DiscreteVector<DDims>(value))...);
+}
+
 template <typename... DDim>
 ddc::StridedDiscreteDomain<DDim...> to_strided_ddom(ddc::DiscreteDomain<DDim...> const& ddom)
 {
-    return ddc::StridedDiscreteDomain<DDim...>(
-            ddom.front(),
-            ddom.extents(),
-            make_discrete_vector<DDim...>::exec(std::make_index_sequence<sizeof...(DDim)> {}));
+    return ddc::StridedDiscreteDomain<
+            DDim...>(ddom.front(), ddom.extents(), make_discrete_vector<DDim...>(1));
 }
 
 // TODO: document, rename

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -628,9 +628,7 @@ public:
      *
      * @param[out] spline The coefficients of the spline computed by this SplineBuilder.
      * @param[in] vals The values of the function on the interpolation mesh.
-     * @param[in] derivs_xmin The values of the derivatives at the lower boundary
-     * (used only with BoundCond::HERMITE lower boundary condition).
-     * @param[in] derivs_xmax The values of the derivatives at the upper boundary
+     * @param[in] derivs The values of the derivatives.
      * (used only with BoundCond::HERMITE upper boundary condition).
      */
     template <class Layout, class StridedLayout, class BatchedInterpolationDDom>

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -637,12 +637,6 @@ operator()(
     // TODO: perform computations along dimension 1 on different streams ?
 
     // Spline1-approximate derivs_min2 (to spline1_deriv_min)
-    whole_derivs_domain_type2<BatchedInterpolationDDom> const batched_deriv_domain
-            = ddc::detail::get_whole_derivs_domain<deriv_type2>(
-                    ddc::select<ddim2>(batched_interpolation_domain),
-                    batched_interpolation_domain,
-                    bsplines_type2::degree() / 2);
-
     auto const spline_batched_deriv_domain = ddc::detail::get_whole_derivs_domain<deriv_type2>(
             ddc::select<ddim2>(batched_interpolation_domain),
             m_spline_builder_deriv1.batched_spline_domain(batched_interpolation_domain),

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -262,7 +262,16 @@ public:
     using batched_derivs_domain_type1 =
             typename builder_type1::template batched_derivs_domain_type<BatchedInterpolationDDom>;
 
-    // FIXME: add doc comment
+    /**
+     * @brief The type of the whole Derivs domain (1D dimension of interest and cartesian
+     * product of 1D Deriv domain and batch domain) in the first dimension to be passed as argument to the buider,
+     * preserving the underlying memory layout (order of dimensions).
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
+     * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
+     * this is StridedDiscreteDomain<X, Deriv<X>, Y, Z>
+     */
     template <
             class BatchedInterpolationDDom,
             class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
@@ -286,7 +295,16 @@ public:
             interpolation_discrete_dimension_type2,
             deriv_type2>;
 
-    // FIXME: add doc comment
+    /**
+     * @brief The type of the whole Derivs domain (1D dimension of interest and cartesian
+     * product of 1D Deriv domain and batch domain) in the second dimension to be passed as argument to the buider,
+     * preserving the underlying memory layout (order of dimensions).
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
+     * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
+     * this is StridedDiscreteDomain<Y, X, Deriv<Y>, Z>
+     */
     template <
             class BatchedInterpolationDDom,
             class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
@@ -313,7 +331,16 @@ public:
                             interpolation_discrete_dimension_type2>,
                     ddc::detail::TypeSeq<deriv_type1, deriv_type2>>>;
 
-    // FIXME: add doc comment
+    /**
+     * @brief The type of the whole Derivs domain (all dimensions of interest and cartesian
+     * product of 2D Deriv domain and batch domain) to be passed as argument to the buider,
+     * preserving the underlying memory layout (order of dimensions).
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
+     * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
+     * this is StridedDiscreteDomain<X, Y, Deriv<X>, Deriv<Y>, Z>
+     */
     template <
             class BatchedInterpolationDDom,
             class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -15,6 +15,111 @@
 
 namespace ddc {
 
+namespace detail {
+template <typename ElementType, typename Layout, typename MemorySpace, typename... DDims>
+auto strided_to_discrete_domain_chunkspan(
+        ddc::ChunkSpan<
+                ElementType,
+                ddc::StridedDiscreteDomain<DDims...>,
+                Layout,
+                MemorySpace> const& cs)
+{
+    assert(((cs.domain().strides().template get<DDims>() == 1) && ...));
+    return ddc::ChunkSpan<ElementType, ddc::DiscreteDomain<DDims...>, Layout, MemorySpace>(
+            cs.data_handle(),
+            ddc::DiscreteDomain<DDims...>(cs.domain().front(), cs.domain().extents()));
+}
+
+template <typename ElementType, typename Layout, typename MemorySpace, typename... DDims>
+auto discrete_to_strided_domain_chunkspan(
+        ddc::ChunkSpan<ElementType, ddc::DiscreteDomain<DDims...>, Layout, MemorySpace> const& cs)
+{
+    return ddc::ChunkSpan<ElementType, ddc::StridedDiscreteDomain<DDims...>, Layout, MemorySpace>(
+            cs.data_handle(),
+            ddc::StridedDiscreteDomain<DDims...>(
+                    cs.domain().front(),
+                    cs.domain().extents(),
+                    make_discrete_vector<DDims...>(1)));
+}
+
+template <typename Dim>
+struct Min
+{
+};
+
+template <typename Dim>
+constexpr Min<Dim> dmin;
+
+template <typename Dim>
+struct Max
+{
+};
+
+template <typename Dim>
+constexpr Max<Dim> dmax;
+
+template <typename... DDims, typename T, typename Support, class Layout, class MemorySpace>
+auto derivs(
+        ddc::ChunkSpan<T, Support, Layout, MemorySpace> const& derivs_span,
+        ddc::DiscreteElement<DDims...> delem)
+{
+    return derivs_span[delem];
+}
+
+template <
+        typename DerivDim,
+        typename... DerivDims,
+        typename... DDims,
+        typename T,
+        typename Support,
+        class Layout,
+        class MemorySpace>
+auto derivs(
+        ddc::ChunkSpan<T, Support, Layout, MemorySpace> const& derivs_span,
+        ddc::DiscreteElement<DDims...> delem,
+        Min<DerivDim>,
+        DerivDims... deriv_dims)
+{
+    return derivs(
+            derivs_span,
+            ddc::DiscreteElement<
+                    DDims...,
+                    DerivDim>(delem, ddc::DiscreteElement<DerivDim>(derivs_span.domain().front())),
+            deriv_dims...);
+}
+
+template <
+        typename DerivDim,
+        typename... DerivDims,
+        typename... DDims,
+        typename T,
+        typename Support,
+        class Layout,
+        class MemorySpace>
+auto derivs(
+        ddc::ChunkSpan<T, Support, Layout, MemorySpace> const& derivs_span,
+        ddc::DiscreteElement<DDims...> delem,
+        Max<DerivDim>,
+        DerivDims... deriv_dims)
+{
+    return derivs(
+            derivs_span,
+            ddc::DiscreteElement<
+                    DDims...,
+                    DerivDim>(delem, ddc::DiscreteElement<DerivDim>(derivs_span.domain().back())),
+            deriv_dims...);
+}
+
+template <typename... DerivDims, typename T, typename Support, class Layout, class MemorySpace>
+auto derivs(
+        ddc::ChunkSpan<T, Support, Layout, MemorySpace> const& derivs_span,
+        DerivDims... deriv_dims)
+{
+    return derivs(derivs_span, ddc::DiscreteElement<>(), deriv_dims...);
+}
+
+} // namespace detail
+
 /**
  * @brief A class for creating a 2D spline approximation of a function.
  *
@@ -157,6 +262,13 @@ public:
     using batched_derivs_domain_type1 =
             typename builder_type1::template batched_derivs_domain_type<BatchedInterpolationDDom>;
 
+    // FIXME: add doc comment
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using whole_derivs_domain_type1 =
+            typename builder_type1::template whole_derivs_domain_type<BatchedInterpolationDDom>;
+
     /**
      * @brief The type of the whole Derivs domain (cartesian product of the 1D Deriv domain
      * and the associated batch domain) in the second dimension, preserving the order of dimensions.
@@ -173,6 +285,13 @@ public:
             BatchedInterpolationDDom,
             interpolation_discrete_dimension_type2,
             deriv_type2>;
+
+    // FIXME: add doc comment
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using whole_derivs_domain_type2 =
+            typename builder_type2::template whole_derivs_domain_type<BatchedInterpolationDDom>;
 
     /**
      * @brief The type of the whole Derivs domain (cartesian product of the 2D Deriv domain
@@ -193,6 +312,20 @@ public:
                             interpolation_discrete_dimension_type1,
                             interpolation_discrete_dimension_type2>,
                     ddc::detail::TypeSeq<deriv_type1, deriv_type2>>>;
+
+    // FIXME: add doc comment
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using whole_derivs_domain_type
+            = ddc::detail::convert_type_seq_to_strided_discrete_domain_t<ddc::type_seq_cat_t<
+                    ddc::to_type_seq_t<interpolation_domain_type>,
+                    ddc::type_seq_replace_t<
+                            ddc::to_type_seq_t<BatchedInterpolationDDom>,
+                            ddc::detail::TypeSeq<
+                                    interpolation_discrete_dimension_type1,
+                                    interpolation_discrete_dimension_type2>,
+                            ddc::detail::TypeSeq<deriv_type1, deriv_type2>>>>;
 
 private:
     builder_type1 m_spline_builder1;
@@ -384,28 +517,14 @@ public:
      *      The coefficients of the spline computed by this SplineBuilder.
      * @param[in] vals
      *      The values of the function at the interpolation mesh.
-     * @param[in] derivs_min1
-     *      The values of the derivatives at the lower boundary in the first dimension.
-     * @param[in] derivs_max1
-     *      The values of the derivatives at the upper boundary in the first dimension.
-     * @param[in] derivs_min2
-     *      The values of the derivatives at the lower boundary in the second dimension.
-     * @param[in] derivs_max2
-     *      The values of the derivatives at the upper boundary in the second dimension.
-     * @param[in] mixed_derivs_min1_min2
-     *      The values of the the cross-derivatives at the lower boundary in the first dimension
-     *      and the lower boundary in the second dimension.
-     * @param[in] mixed_derivs_max1_min2
-     *      The values of the the cross-derivatives at the upper boundary in the first dimension
-     *      and the lower boundary in the second dimension.
-     * @param[in] mixed_derivs_min1_max2
-     *      The values of the the cross-derivatives at the lower boundary in the first dimension
-     *      and the upper boundary in the second dimension.
-     * @param[in] mixed_derivs_max1_max2
-     *      The values of the the cross-derivatives at the upper boundary in the first dimension
-     *      and the upper boundary in the second dimension.
+     * @param[in] derivs1
+     *      The values of the derivatives in the first dimension.
+     * @param[in] derivs2
+     *      The values of the derivatives in the second dimension.
+     * @param[in] mixed_derivs_1_2
+     *      The values of the the cross-derivatives in the first and the second dimension.
      */
-    template <class Layout, class BatchedInterpolationDDom>
+    template <class Layout, class DerivsLayout, class BatchedInterpolationDDom>
     void operator()(
             ddc::ChunkSpan<
                     double,
@@ -413,54 +532,21 @@ public:
                     Layout,
                     memory_space> spline,
             ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
-            std::optional<ddc::ChunkSpan<
+            ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type1<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> derivs_min1
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
+                    whole_derivs_domain_type1<BatchedInterpolationDDom>,
+                    DerivsLayout,
+                    memory_space> derivs1,
+            ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type1<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> derivs_max1
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
+                    whole_derivs_domain_type2<BatchedInterpolationDDom>,
+                    DerivsLayout,
+                    memory_space> derivs2,
+            ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type2<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> derivs_min2
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type2<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> derivs_max2
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_min1_min2
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_max1_min2
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_min1_max2
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_max1_max2
-            = std::nullopt) const;
+                    whole_derivs_domain_type<BatchedInterpolationDDom>,
+                    DerivsLayout,
+                    memory_space> mixed_derivs_1_2) const;
 };
 
 
@@ -476,7 +562,7 @@ template <
         ddc::BoundCond BcLower2,
         ddc::BoundCond BcUpper2,
         ddc::SplineSolver Solver>
-template <class Layout, class BatchedInterpolationDDom>
+template <class Layout, class DerivsLayout, class BatchedInterpolationDDom>
 void SplineBuilder2D<
         ExecSpace,
         MemorySpace,
@@ -496,74 +582,62 @@ operator()(
                 Layout,
                 memory_space> spline,
         ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
-        std::optional<ddc::ChunkSpan<
+        ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type1<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> const derivs_min1,
-        std::optional<ddc::ChunkSpan<
+                whole_derivs_domain_type1<BatchedInterpolationDDom>,
+                DerivsLayout,
+                memory_space> derivs1,
+        ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type1<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> const derivs_max1,
-        std::optional<ddc::ChunkSpan<
+                whole_derivs_domain_type2<BatchedInterpolationDDom>,
+                DerivsLayout,
+                memory_space> derivs2,
+        ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type2<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> const derivs_min2,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type2<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> const derivs_max2,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> const mixed_derivs_min1_min2,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> const mixed_derivs_max1_min2,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> const mixed_derivs_min1_max2,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> const mixed_derivs_max1_max2) const
+                whole_derivs_domain_type<BatchedInterpolationDDom>,
+                DerivsLayout,
+                memory_space> mixed_derivs_1_2) const
 {
     auto const batched_interpolation_domain = vals.domain();
+
+    using ddim1 = interpolation_discrete_dimension_type1;
+    using ddim2 = interpolation_discrete_dimension_type2;
+    using detail::dmax;
+    using detail::dmin;
 
     assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
 
     // TODO: perform computations along dimension 1 on different streams ?
+
     // Spline1-approximate derivs_min2 (to spline1_deriv_min)
-
-    auto const batched_interpolation_deriv_domain
-            = ddc::replace_dim_of<interpolation_discrete_dimension_type2, deriv_type2>(
+    whole_derivs_domain_type2<BatchedInterpolationDDom> const batched_deriv_domain
+            = ddc::detail::get_whole_derivs_domain<deriv_type2>(
+                    ddc::select<ddim2>(batched_interpolation_domain),
                     batched_interpolation_domain,
-                    ddc::DiscreteDomain<deriv_type2>(
-                            ddc::DiscreteElement<deriv_type2>(1),
-                            ddc::DiscreteVector<deriv_type2>(bsplines_type2::degree() / 2)));
+                    bsplines_type2::degree());
 
-    ddc::Chunk spline1_deriv_min_alloc(
-            m_spline_builder_deriv1.batched_spline_domain(batched_interpolation_deriv_domain),
+    auto const spline_batched_deriv_domain = ddc::detail::get_whole_derivs_domain<deriv_type2>(
+            ddc::select<ddim2>(batched_interpolation_domain),
+            m_spline_builder_deriv1.batched_spline_domain(batched_interpolation_domain),
+            bsplines_type2::degree());
+
+    ddc::Chunk spline1_deriv_alloc(
+            spline_batched_deriv_domain,
             ddc::KokkosAllocator<double, MemorySpace>());
-    auto spline1_deriv_min = spline1_deriv_min_alloc.span_view();
-    auto spline1_deriv_min_opt = std::optional(spline1_deriv_min.span_cview());
+    auto spline1_deriv = spline1_deriv_alloc.span_view();
+
     if constexpr (BcLower2 == ddc::BoundCond::HERMITE) {
+        auto const spline1_deriv_min_strided = detail::derivs(spline1_deriv, dmin<ddim2>);
+        auto const spline1_deriv_min
+                = detail::strided_to_discrete_domain_chunkspan(spline1_deriv_min_strided);
+
+        auto const derivs_min2_strided = detail::derivs(derivs2, dmin<ddim2>);
+        auto const derivs_min2 = detail::strided_to_discrete_domain_chunkspan(derivs_min2_strided);
+
         m_spline_builder_deriv1(
                 spline1_deriv_min,
-                *derivs_min2,
-                mixed_derivs_min1_min2,
-                mixed_derivs_max1_min2);
-    } else {
-        spline1_deriv_min_opt = std::nullopt;
+                derivs_min2,
+                detail::derivs(mixed_derivs_1_2, dmin<ddim2>));
     }
 
     // Spline1-approximate vals (to spline1)
@@ -572,26 +646,25 @@ operator()(
             ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan const spline1 = spline1_alloc.span_view();
 
-    m_spline_builder1(spline1, vals, derivs_min1, derivs_max1);
+    m_spline_builder1(spline1, vals, derivs1);
 
     // Spline1-approximate derivs_max2 (to spline1_deriv_max)
-    ddc::Chunk spline1_deriv_max_alloc(
-            m_spline_builder_deriv1.batched_spline_domain(batched_interpolation_deriv_domain),
-            ddc::KokkosAllocator<double, MemorySpace>());
-    auto spline1_deriv_max = spline1_deriv_max_alloc.span_view();
-    auto spline1_deriv_max_opt = std::optional(spline1_deriv_max.span_cview());
     if constexpr (BcUpper2 == ddc::BoundCond::HERMITE) {
+        auto const spline1_deriv_max_strided = detail::derivs(spline1_deriv, dmax<ddim2>);
+        auto const spline1_deriv_max
+                = detail::strided_to_discrete_domain_chunkspan(spline1_deriv_max_strided);
+
+        auto const derivs_max2_strided = detail::derivs(derivs2, dmax<ddim2>);
+        auto const derivs_max2 = detail::strided_to_discrete_domain_chunkspan(derivs_max2_strided);
+
         m_spline_builder_deriv1(
                 spline1_deriv_max,
-                *derivs_max2,
-                mixed_derivs_min1_max2,
-                mixed_derivs_max1_max2);
-    } else {
-        spline1_deriv_max_opt = std::nullopt;
+                derivs_max2,
+                detail::derivs(mixed_derivs_1_2, dmax<ddim2>));
     }
 
     // Spline2-approximate spline1
-    m_spline_builder2(spline, spline1.span_cview(), spline1_deriv_min_opt, spline1_deriv_max_opt);
+    m_spline_builder2(spline, spline1.span_cview(), spline1_deriv.span_cview());
 }
 
 } // namespace ddc

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -614,12 +614,12 @@ operator()(
             = ddc::detail::get_whole_derivs_domain<deriv_type2>(
                     ddc::select<ddim2>(batched_interpolation_domain),
                     batched_interpolation_domain,
-                    bsplines_type2::degree());
+                    bsplines_type2::degree() / 2);
 
     auto const spline_batched_deriv_domain = ddc::detail::get_whole_derivs_domain<deriv_type2>(
             ddc::select<ddim2>(batched_interpolation_domain),
             m_spline_builder_deriv1.batched_spline_domain(batched_interpolation_domain),
-            bsplines_type2::degree());
+            bsplines_type2::degree() / 2);
 
     ddc::Chunk spline1_deriv_alloc(
             spline_batched_deriv_domain,

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -264,7 +264,7 @@ public:
 
     /**
      * @brief The type of the whole Derivs domain (1D dimension of interest and cartesian
-     * product of 1D Deriv domain and batch domain) in the first dimension to be passed as argument to the buider,
+     * product of 1D Deriv domain and batch domain) in the first dimension to be passed as argument to the builder,
      * preserving the underlying memory layout (order of dimensions).
      *
      * @tparam The batched discrete domain on which the interpolation points are defined.
@@ -297,7 +297,7 @@ public:
 
     /**
      * @brief The type of the whole Derivs domain (1D dimension of interest and cartesian
-     * product of 1D Deriv domain and batch domain) in the second dimension to be passed as argument to the buider,
+     * product of 1D Deriv domain and batch domain) in the second dimension to be passed as argument to the builder,
      * preserving the underlying memory layout (order of dimensions).
      *
      * @tparam The batched discrete domain on which the interpolation points are defined.
@@ -333,7 +333,7 @@ public:
 
     /**
      * @brief The type of the whole Derivs domain (all dimensions of interest and cartesian
-     * product of 2D Deriv domain and batch domain) to be passed as argument to the buider,
+     * product of 2D Deriv domain and batch domain) to be passed as argument to the builder,
      * preserving the underlying memory layout (order of dimensions).
      *
      * @tparam The batched discrete domain on which the interpolation points are defined.

--- a/include/ddc/kernels/splines/spline_builder_3d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_3d.hpp
@@ -777,7 +777,6 @@ operator()(
 {
     auto const batched_interpolation_domain = vals.domain();
 
-    using ddim1 = interpolation_discrete_dimension_type1;
     using ddim2 = interpolation_discrete_dimension_type2;
     using ddim3 = interpolation_discrete_dimension_type3;
     using detail::dmax;

--- a/include/ddc/kernels/splines/spline_builder_3d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_3d.hpp
@@ -191,6 +191,24 @@ public:
             deriv_type1>;
 
     /**
+     * @brief The type of the whole Derivs domain (1D dimension of interest and cartesian
+     * product of 1D Deriv domain and batch domain) in the first dimension, to be passed as
+     * argument to the buider, preserving the underlying memory layout (order of dimensions).
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
+     * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z,T> and dimensions of interest X, Y and Z,
+     * this is StridedDiscreteDomain<X, Deriv<X>, Y, Z, T>
+     */
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using whole_derivs_domain_type1 = detail::to_whole_derivs_domain_t<
+            ddc::detail::TypeSeq<interpolation_discrete_dimension_type1>,
+            ddc::detail::TypeSeq<deriv_type1>,
+            ddc::to_type_seq_t<BatchedInterpolationDDom>>;
+
+    /**
      * @brief The type of the whole Derivs domain (cartesian product of the 1D Deriv domain
      * and the associated batch domain) in the second dimension, preserving the order of dimensions.
      *
@@ -208,6 +226,24 @@ public:
             deriv_type2>;
 
     /**
+     * @brief The type of the whole Derivs domain (1D dimension of interest and cartesian
+     * product of 1D Deriv domain and batch domain) in the second dimension, to be passed as
+     * argument to the buider, preserving the underlying memory layout (order of dimensions).
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
+     * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z,T> and dimensions of interest X, Y and Z,
+     * this is StridedDiscreteDomain<Y, X, Deriv<Y>, Z, T>
+     */
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using whole_derivs_domain_type2 = detail::to_whole_derivs_domain_t<
+            ddc::detail::TypeSeq<interpolation_discrete_dimension_type2>,
+            ddc::detail::TypeSeq<deriv_type2>,
+            ddc::to_type_seq_t<BatchedInterpolationDDom>>;
+
+    /**
      * @brief The type of the whole Derivs domain (cartesian product of the 1D Deriv domain
      * and the associated batch domain) in the third dimension, preserving the order of dimensions.
      *
@@ -223,6 +259,24 @@ public:
             BatchedInterpolationDDom,
             interpolation_discrete_dimension_type3,
             deriv_type3>;
+
+    /**
+     * @brief The type of the whole Derivs domain (1D dimension of interest and cartesian
+     * product of 1D Deriv domain and batch domain) in the third dimension, to be passed as
+     * argument to the buider, preserving the underlying memory layout (order of dimensions).
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
+     * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z,T> and dimensions of interest X, Y and Z,
+     * this is StridedDiscreteDomain<Z, X, Y, Deriv<Z>, T>
+     */
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using whole_derivs_domain_type3 = detail::to_whole_derivs_domain_t<
+            ddc::detail::TypeSeq<interpolation_discrete_dimension_type3>,
+            ddc::detail::TypeSeq<deriv_type3>,
+            ddc::to_type_seq_t<BatchedInterpolationDDom>>;
 
     /**
      * @brief The type of the whole Derivs domain (cartesian product of the 2D Deriv domain
@@ -247,6 +301,26 @@ public:
 
     /**
      * @brief The type of the whole Derivs domain (cartesian product of the 2D Deriv domain
+     * and the associated batch domain) in the first and second dimensions, to be passed
+     * as argument to the builder, preserving the order of dimensions.
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
+     * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z,T> and dimensions of interest X, Y and Z,
+     * this is StridedDiscreteDomain<X, Y, Deriv<X>, Deriv<Y>, Z, T>
+     */
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using whole_derivs_domain_type1_2 = detail::to_whole_derivs_domain_t<
+            ddc::detail::TypeSeq<
+                    interpolation_discrete_dimension_type1,
+                    interpolation_discrete_dimension_type2>,
+            ddc::detail::TypeSeq<deriv_type1, deriv_type2>,
+            ddc::to_type_seq_t<BatchedInterpolationDDom>>;
+
+    /**
+     * @brief The type of the whole Derivs domain (cartesian product of the 2D Deriv domain
      * and the associated batch domain) in the second and third dimensions, preserving the order
      * of dimensions.
      *
@@ -265,6 +339,26 @@ public:
                     deriv_type2>,
             interpolation_domain_type3,
             deriv_type3>;
+
+    /**
+     * @brief The type of the whole Derivs domain (cartesian product of the 2D Deriv domain
+     * and the associated batch domain) in the second and third dimensions, to be passed
+     * as argument to the builder, preserving the order of dimensions.
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
+     * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z,T> and dimensions of interest X, Y and Z,
+     * this is StridedDiscreteDomain<Y, Z, X, Deriv<Y>, Deriv<Z>, T>
+     */
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using whole_derivs_domain_type2_3 = detail::to_whole_derivs_domain_t<
+            ddc::detail::TypeSeq<
+                    interpolation_discrete_dimension_type2,
+                    interpolation_discrete_dimension_type3>,
+            ddc::detail::TypeSeq<deriv_type2, deriv_type3>,
+            ddc::to_type_seq_t<BatchedInterpolationDDom>>;
 
     /**
      * @brief The type of the whole Derivs domain (cartesian product of the 2D Deriv domain
@@ -288,6 +382,26 @@ public:
             deriv_type3>;
 
     /**
+     * @brief The type of the whole Derivs domain (cartesian product of the 2D Deriv domain
+     * and the associated batch domain) in the first and third dimensions, to be passed
+     * as argument to the builder, preserving the order of dimensions.
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
+     * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z,T> and dimensions of interest X, Y and Z,
+     * this is StridedDiscreteDomain<X, Z, Deriv<X>, Y, Deriv<Z>, T>
+     */
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using whole_derivs_domain_type1_3 = detail::to_whole_derivs_domain_t<
+            ddc::detail::TypeSeq<
+                    interpolation_discrete_dimension_type1,
+                    interpolation_discrete_dimension_type3>,
+            ddc::detail::TypeSeq<deriv_type1, deriv_type3>,
+            ddc::to_type_seq_t<BatchedInterpolationDDom>>;
+
+    /**
      * @brief The type of the whole Derivs domain (cartesian product of the 3D Deriv domain
      * and the batch domain), preserving the order of dimensions.
      *
@@ -307,6 +421,27 @@ public:
                             interpolation_discrete_dimension_type2,
                             interpolation_discrete_dimension_type3>,
                     ddc::detail::TypeSeq<deriv_type1, deriv_type2, deriv_type3>>>;
+
+    /**
+     * @brief The type of the whole Derivs domain (cartesian product of the 3D Deriv domain
+     * and the associated batch domain) to be passed as argument to the builder, preserving
+     * the order of dimensions.
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
+     * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z,T> and dimensions of interest X, Y and Z,
+     * this is StridedDiscreteDomain<X, Y, Z, Deriv<X>, Deriv<Y>, Deriv<Z>, T>
+     */
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using whole_derivs_domain_type = detail::to_whole_derivs_domain_t<
+            ddc::detail::TypeSeq<
+                    interpolation_discrete_dimension_type1,
+                    interpolation_discrete_dimension_type2,
+                    interpolation_discrete_dimension_type3>,
+            ddc::detail::TypeSeq<deriv_type1, deriv_type2, deriv_type3>,
+            ddc::to_type_seq_t<BatchedInterpolationDDom>>;
 
 private:
     builder_type1 m_spline_builder1;
@@ -503,60 +638,22 @@ public:
      *      The coefficients of the spline computed by this SplineBuilder.
      * @param[in] vals
      *      The values of the function at the interpolation mesh.
-     * @param[in] derivs_min1
-     *      The values of the derivatives at the lower boundary in the first dimension.
-     * @param[in] derivs_max1
-     *      The values of the derivatives at the upper boundary in the first dimension.
-     * @param[in] derivs_min2
-     *      The values of the derivatives at the lower boundary in the second dimension.
-     * @param[in] derivs_max2
-     *      The values of the derivatives at the upper boundary in the second dimension.
-     * @param[in] derivs_min3
-     *      The values of the derivatives at the lower boundary in the third dimension.
-     * @param[in] derivs_max3
-     *      The values of the derivatives at the upper boundary in the third dimension.
-     * @param[in] mixed_derivs_min1_min2
-     *      The values of the the cross-derivatives at the lower boundary in the first dimension and the lower boundary in the second dimension.
-     * @param[in] mixed_derivs_max1_min2
-     *      The values of the the cross-derivatives at the upper boundary in the first dimension and the lower boundary in the second dimension.
-     * @param[in] mixed_derivs_min1_max2
-     *      The values of the the cross-derivatives at the lower boundary in the first dimension and the upper boundary in the second dimension.
-     * @param[in] mixed_derivs_max1_max2
-     *      The values of the the cross-derivatives at the upper boundary in the first dimension and the upper boundary in the second dimension.
-     * @param[in] mixed_derivs_min2_min3
-     *      The values of the the cross-derivatives at the lower boundary in the second dimension and the lower boundary in the third dimension.
-     * @param[in] mixed_derivs_max2_min3
-     *      The values of the the cross-derivatives at the upper boundary in the second dimension and the lower boundary in the third dimension.
-     * @param[in] mixed_derivs_min2_max3
-     *      The values of the the cross-derivatives at the lower boundary in the second dimension and the upper boundary in the third dimension.
-     * @param[in] mixed_derivs_max2_max3
-     *      The values of the the cross-derivatives at the upper boundary in the second dimension and the upper boundary in the third dimension.
-     * @param[in] mixed_derivs_min1_min3
-     *      The values of the the cross-derivatives at the lower boundary in the first dimension and the lower boundary in the third dimension.
-     * @param[in] mixed_derivs_max1_min3
-     *      The values of the the cross-derivatives at the upper boundary in the first dimension and the lower boundary in the third dimension.
-     * @param[in] mixed_derivs_min1_max3
-     *      The values of the the cross-derivatives at the lower boundary in the first dimension and the upper boundary in the third dimension.
-     * @param[in] mixed_derivs_max1_max3
-     *      The values of the the cross-derivatives at the upper boundary in the first dimension and the upper boundary in the third dimension.
-     * @param[in] mixed_derivs_min1_min2_min3
-     *      The values of the the cross-derivatives at the lower boundary in the first dimension, the lower boundary in the second dimension and the lower boundary in the third dimension.
-     * @param[in] mixed_derivs_max1_min2_min3
-     *      The values of the the cross-derivatives at the upper boundary in the first dimension, the lower boundary in the second dimension and the lower boundary in the third dimension.
-     * @param[in] mixed_derivs_min1_max2_min3
-     *      The values of the the cross-derivatives at the lower boundary in the first dimension, the upper boundary in the second dimension and the lower boundary in the third dimension.
-     * @param[in] mixed_derivs_max1_max2_min3
-     *      The values of the the cross-derivatives at the upper boundary in the first dimension, the upper boundary in the second dimension and the lower boundary in the third dimension.
-     * @param[in] mixed_derivs_min1_min2_max3
-     *      The values of the the cross-derivatives at the lower boundary in the first dimension, the lower boundary in the second dimension and the upper boundary in the third dimension.
-     * @param[in] mixed_derivs_max1_min2_max3
-     *      The values of the the cross-derivatives at the upper boundary in the first dimension, the lower boundary in the second dimension and the upper boundary in the third dimension.
-     * @param[in] mixed_derivs_min1_max2_max3
-     *      The values of the the cross-derivatives at the lower boundary in the first dimension, the upper boundary in the second dimension and the upper boundary in the third dimension.
-     * @param[in] mixed_derivs_max1_max2_max3
-     *      The values of the the cross-derivatives at the upper boundary in the first dimension, the upper boundary in the second dimension and the upper boundary in the third dimension.
+     * @param[in] derivs1
+     *      The values of the derivatives in the first dimension.
+     * @param[in] derivs2
+     *      The values of the derivatives in the second dimension.
+     * @param[in] derivs3
+     *      The values of the derivatives in the third dimension.
+     * @param[in] mixed_derivs1_2
+     *      The values of the the cross-derivatives in the first dimension and in the second dimension.
+     * @param[in] mixed_derivs2_3
+     *      The values of the the cross-derivatives in the second dimension and in the third dimension.
+     * @param[in] mixed_derivs1_3
+     *      The values of the the cross-derivatives in the first dimension and in the third dimension.
+     * @param[in] mixed_derivs1_2_3
+     *      The values of the the cross-derivatives in the first dimension, in the second dimension and in the third dimension.
      */
-    template <class Layout, class BatchedInterpolationDDom>
+    template <class Layout, class DerivsLayout, class BatchedInterpolationDDom>
     void operator()(
             ddc::ChunkSpan<
                     double,
@@ -564,162 +661,41 @@ public:
                     Layout,
                     memory_space> spline,
             ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
-            std::optional<ddc::ChunkSpan<
+            ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type1<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> derivs_min1
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
+                    whole_derivs_domain_type1<BatchedInterpolationDDom>,
+                    DerivsLayout,
+                    memory_space> derivs1,
+            ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type1<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> derivs_max1
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
+                    whole_derivs_domain_type2<BatchedInterpolationDDom>,
+                    DerivsLayout,
+                    memory_space> derivs2,
+            ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type2<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> derivs_min2
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
+                    whole_derivs_domain_type3<BatchedInterpolationDDom>,
+                    DerivsLayout,
+                    memory_space> derivs3,
+            ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type2<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> derivs_max2
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
+                    whole_derivs_domain_type1_2<BatchedInterpolationDDom>,
+                    DerivsLayout,
+                    memory_space> mixed_derivs1_2,
+            ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type3<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> derivs_min3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
+                    whole_derivs_domain_type2_3<BatchedInterpolationDDom>,
+                    DerivsLayout,
+                    memory_space> mixed_derivs2_3,
+            ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type3<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> derivs_max3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
+                    whole_derivs_domain_type1_3<BatchedInterpolationDDom>,
+                    DerivsLayout,
+                    memory_space> mixed_derivs1_3,
+            ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_min1_min2
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_max1_min2
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_min1_max2
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_max1_max2
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_min2_min3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_max2_min3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_min2_max3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_max2_max3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_min1_min3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_max1_min3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_min1_max3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_max1_max3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_min1_min2_min3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_max1_min2_min3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_min1_max2_min3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_max1_max2_min3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_min1_min2_max3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_max1_min2_max3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_min1_max2_max3
-            = std::nullopt,
-            std::optional<ddc::ChunkSpan<
-                    double const,
-                    batched_derivs_domain_type<BatchedInterpolationDDom>,
-                    Layout,
-                    memory_space>> mixed_derivs_max1_max2_max3
-            = std::nullopt) const;
+                    whole_derivs_domain_type<BatchedInterpolationDDom>,
+                    DerivsLayout,
+                    memory_space> mixed_derivs1_2_3) const;
 };
 
 
@@ -739,7 +715,7 @@ template <
         ddc::BoundCond BcLower3,
         ddc::BoundCond BcUpper3,
         ddc::SplineSolver Solver>
-template <class Layout, class BatchedInterpolationDDom>
+template <class Layout, class DerivsLayout, class BatchedInterpolationDDom>
 void SplineBuilder3D<
         ExecSpace,
         MemorySpace,
@@ -763,283 +739,201 @@ operator()(
                 Layout,
                 memory_space> spline,
         ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
-        std::optional<ddc::ChunkSpan<
+        ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type1<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> derivs_min1,
-        std::optional<ddc::ChunkSpan<
+                whole_derivs_domain_type1<BatchedInterpolationDDom>,
+                DerivsLayout,
+                memory_space> derivs1,
+        ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type1<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> derivs_max1,
-        std::optional<ddc::ChunkSpan<
+                whole_derivs_domain_type2<BatchedInterpolationDDom>,
+                DerivsLayout,
+                memory_space> derivs2,
+        ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type2<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> derivs_min2,
-        std::optional<ddc::ChunkSpan<
+                whole_derivs_domain_type3<BatchedInterpolationDDom>,
+                DerivsLayout,
+                memory_space> derivs3,
+        ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type2<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> derivs_max2,
-        std::optional<ddc::ChunkSpan<
+                whole_derivs_domain_type1_2<BatchedInterpolationDDom>,
+                DerivsLayout,
+                memory_space> mixed_derivs1_2,
+        ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type3<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> derivs_min3,
-        std::optional<ddc::ChunkSpan<
+                whole_derivs_domain_type2_3<BatchedInterpolationDDom>,
+                DerivsLayout,
+                memory_space> mixed_derivs2_3,
+        ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type3<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> derivs_max3,
-        std::optional<ddc::ChunkSpan<
+                whole_derivs_domain_type1_3<BatchedInterpolationDDom>,
+                DerivsLayout,
+                memory_space> mixed_derivs1_3,
+        ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_min1_min2,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_max1_min2,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_min1_max2,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_max1_max2,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_min2_min3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_max2_min3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_min2_max3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_max2_max3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_min1_min3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_max1_min3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_min1_max3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_max1_max3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_min1_min2_min3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_max1_min2_min3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_min1_max2_min3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_max1_max2_min3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_min1_min2_max3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_max1_min2_max3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_min1_max2_max3,
-        std::optional<ddc::ChunkSpan<
-                double const,
-                batched_derivs_domain_type<BatchedInterpolationDDom>,
-                Layout,
-                memory_space>> mixed_derivs_max1_max2_max3) const
+                whole_derivs_domain_type<BatchedInterpolationDDom>,
+                DerivsLayout,
+                memory_space> mixed_derivs1_2_3) const
 {
     auto const batched_interpolation_domain = vals.domain();
+
+    using ddim1 = interpolation_discrete_dimension_type1;
+    using ddim2 = interpolation_discrete_dimension_type2;
+    using ddim3 = interpolation_discrete_dimension_type3;
+    using detail::dmax;
+    using detail::dmin;
 
     assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
 
     // Build the derivatives along the second dimension
-    auto const batched_interpolation_deriv_domain2
-            = ddc::replace_dim_of<interpolation_discrete_dimension_type2, deriv_type2>(
-                    batched_interpolation_domain,
-                    ddc::DiscreteDomain<deriv_type2>(
-                            ddc::DiscreteElement<deriv_type2>(1),
-                            ddc::DiscreteVector<deriv_type2>(bsplines_type2::degree() / 2)));
+    auto const spline_batched_derivs2_domain = ddc::detail::get_whole_derivs_domain<deriv_type2>(
+            ddc::select<ddim2>(batched_interpolation_domain),
+            m_spline_builder1.batched_spline_domain(batched_interpolation_domain),
+            bsplines_type2::degree() / 2);
 
-    ddc::Chunk spline_derivs_min2_alloc(
-            m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain2),
+    ddc::Chunk spline_derivs2_alloc(
+            spline_batched_derivs2_domain,
             ddc::KokkosAllocator<double, MemorySpace>());
-    auto spline_derivs_min2 = spline_derivs_min2_alloc.span_view();
-    auto spline_derivs_min2_opt = std::optional(spline_derivs_min2.span_cview());
+    auto spline_derivs2 = spline_derivs2_alloc.span_view();
+
     if constexpr (BcLower2 == ddc::BoundCond::HERMITE) {
+        auto const spline_derivs_min2_strided = detail::derivs(spline_derivs2, dmin<ddim2>);
+        auto const spline_derivs_min2
+                = detail::strided_to_discrete_domain_chunkspan(spline_derivs_min2_strided);
+
+        auto const derivs_min2_strided = detail::derivs(derivs2, dmin<ddim2>);
+        auto const derivs_min2 = detail::strided_to_discrete_domain_chunkspan(derivs_min2_strided);
         m_spline_builder1(
                 spline_derivs_min2,
-                *derivs_min2,
-                mixed_derivs_min1_min2,
-                mixed_derivs_max1_min2);
-    } else {
-        spline_derivs_min2_opt = std::nullopt;
+                derivs_min2,
+                detail::derivs(mixed_derivs1_2, dmin<ddim2>));
     }
 
-    ddc::Chunk spline_derivs_max2_alloc(
-            m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain2),
-            ddc::KokkosAllocator<double, MemorySpace>());
-    auto spline_derivs_max2 = spline_derivs_max2_alloc.span_view();
-    auto spline_derivs_max2_opt = std::optional(spline_derivs_max2.span_cview());
     if constexpr (BcUpper2 == ddc::BoundCond::HERMITE) {
+        auto const spline_derivs_max2_strided = detail::derivs(spline_derivs2, dmax<ddim2>);
+        auto const spline_derivs_max2
+                = detail::strided_to_discrete_domain_chunkspan(spline_derivs_max2_strided);
+
+        auto const derivs_max2_strided = detail::derivs(derivs2, dmax<ddim2>);
+        auto const derivs_max2 = detail::strided_to_discrete_domain_chunkspan(derivs_max2_strided);
         m_spline_builder1(
                 spline_derivs_max2,
-                *derivs_max2,
-                mixed_derivs_min1_max2,
-                mixed_derivs_max1_max2);
-    } else {
-        spline_derivs_max2_opt = std::nullopt;
+                derivs_max2,
+                detail::derivs(mixed_derivs1_2, dmax<ddim2>));
     }
 
     // Build the derivatives along the third dimension
-    auto const batched_interpolation_deriv_domain3
-            = ddc::replace_dim_of<interpolation_discrete_dimension_type3, deriv_type3>(
-                    batched_interpolation_domain,
-                    ddc::DiscreteDomain<deriv_type3>(
-                            ddc::DiscreteElement<deriv_type3>(1),
-                            ddc::DiscreteVector<deriv_type3>(bsplines_type3::degree() / 2)));
+    auto const spline_batched_derivs3_domain = ddc::detail::get_whole_derivs_domain<deriv_type3>(
+            ddc::select<ddim3>(batched_interpolation_domain),
+            m_spline_builder1.batched_spline_domain(batched_interpolation_domain),
+            bsplines_type3::degree() / 2);
 
-    ddc::Chunk spline_derivs_min3_alloc(
-            m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain3),
+    ddc::Chunk spline_derivs3_alloc(
+            spline_batched_derivs3_domain,
             ddc::KokkosAllocator<double, MemorySpace>());
-    auto spline_derivs_min3 = spline_derivs_min3_alloc.span_view();
-    auto spline_derivs_min3_opt = std::optional(spline_derivs_min3.span_cview());
+    auto spline_derivs3 = spline_derivs3_alloc.span_view();
+
     if constexpr (BcLower3 == ddc::BoundCond::HERMITE) {
+        auto const spline_derivs_min3_strided = detail::derivs(spline_derivs3, dmin<ddim3>);
+        auto const spline_derivs_min3
+                = detail::strided_to_discrete_domain_chunkspan(spline_derivs_min3_strided);
+
+        auto const derivs_min3_strided = detail::derivs(derivs3, dmin<ddim3>);
+        auto const derivs_min3 = detail::strided_to_discrete_domain_chunkspan(derivs_min3_strided);
         m_spline_builder1(
                 spline_derivs_min3,
-                *derivs_min3,
-                mixed_derivs_min1_min3,
-                mixed_derivs_max1_min3);
-    } else {
-        spline_derivs_min3_opt = std::nullopt;
+                derivs_min3,
+                detail::derivs(mixed_derivs1_3, dmin<ddim3>));
     }
 
-    ddc::Chunk spline_derivs_max3_alloc(
-            m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain3),
-            ddc::KokkosAllocator<double, MemorySpace>());
-    auto spline_derivs_max3 = spline_derivs_max3_alloc.span_view();
-    auto spline_derivs_max3_opt = std::optional(spline_derivs_max3.span_cview());
     if constexpr (BcUpper3 == ddc::BoundCond::HERMITE) {
+        auto const spline_derivs_max3_strided = detail::derivs(spline_derivs3, dmax<ddim3>);
+        auto const spline_derivs_max3
+                = detail::strided_to_discrete_domain_chunkspan(spline_derivs_max3_strided);
+
+        auto const derivs_max3_strided = detail::derivs(derivs3, dmax<ddim3>);
+        auto const derivs_max3 = detail::strided_to_discrete_domain_chunkspan(derivs_max3_strided);
         m_spline_builder1(
                 spline_derivs_max3,
-                *derivs_max3,
-                mixed_derivs_min1_max3,
-                mixed_derivs_max1_max3);
-    } else {
-        spline_derivs_max3_opt = std::nullopt;
+                derivs_max3,
+                detail::derivs(mixed_derivs1_3, dmax<ddim3>));
     }
 
     // Build the cross derivatives along the second and third dimensions
-    auto batched_interpolation_deriv_domain2_3
-            = ddc::replace_dim_of<interpolation_discrete_dimension_type3, deriv_type3>(
-                    batched_interpolation_deriv_domain2,
-                    ddc::DiscreteDomain<deriv_type3>(
-                            ddc::DiscreteElement<deriv_type3>(1),
-                            ddc::DiscreteVector<deriv_type3>(bsplines_type3::degree() / 2)));
+    auto const spline_batched_derivs2_3_domain
+            = ddc::detail::get_whole_derivs_domain<deriv_type2, deriv_type3>(
+                    ddc::select<ddim2, ddim3>(batched_interpolation_domain),
+                    m_spline_builder1.batched_spline_domain(batched_interpolation_domain),
+                    bsplines_type2::degree() / 2,
+                    bsplines_type3::degree() / 2);
 
-    ddc::Chunk spline_derivs_min2_min3_alloc(
-            m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain2_3),
+    ddc::Chunk spline_derivs2_3_alloc(
+            spline_batched_derivs2_3_domain,
             ddc::KokkosAllocator<double, MemorySpace>());
-    auto spline_derivs_min2_min3 = spline_derivs_min2_min3_alloc.span_view();
-    auto spline_derivs_min2_min3_opt = std::optional(spline_derivs_min2_min3.span_cview());
+    auto spline_derivs2_3 = spline_derivs2_3_alloc.span_view();
+
     if constexpr (BcLower2 == ddc::BoundCond::HERMITE || BcLower3 == ddc::BoundCond::HERMITE) {
+        auto const spline_derivs_min2_min3_strided
+                = detail::derivs(spline_derivs2_3, dmin<ddim2>, dmin<ddim3>);
+        auto const spline_derivs_min2_min3
+                = detail::strided_to_discrete_domain_chunkspan(spline_derivs_min2_min3_strided);
+
+        auto const derivs_min2_min3_strided
+                = detail::derivs(mixed_derivs2_3, dmin<ddim2>, dmin<ddim3>);
+        auto const derivs_min2_min3
+                = detail::strided_to_discrete_domain_chunkspan(derivs_min2_min3_strided);
         m_spline_builder1(
                 spline_derivs_min2_min3,
-                *mixed_derivs_min2_min3,
-                mixed_derivs_min1_min2_min3,
-                mixed_derivs_max1_min2_min3);
-    } else {
-        spline_derivs_min2_min3_opt = std::nullopt;
+                derivs_min2_min3,
+                detail::derivs(mixed_derivs1_2_3, dmin<ddim2>, dmin<ddim3>));
     }
 
-    ddc::Chunk spline_derivs_min2_max3_alloc(
-            m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain2_3),
-            ddc::KokkosAllocator<double, MemorySpace>());
-    auto spline_derivs_min2_max3 = spline_derivs_min2_max3_alloc.span_view();
-    auto spline_derivs_min2_max3_opt = std::optional(spline_derivs_min2_max3.span_cview());
     if constexpr (BcLower2 == ddc::BoundCond::HERMITE || BcUpper3 == ddc::BoundCond::HERMITE) {
+        auto const spline_derivs_min2_max3_strided
+                = detail::derivs(spline_derivs2_3, dmin<ddim2>, dmax<ddim3>);
+        auto const spline_derivs_min2_max3
+                = detail::strided_to_discrete_domain_chunkspan(spline_derivs_min2_max3_strided);
+
+        auto const derivs_min2_max3_strided
+                = detail::derivs(mixed_derivs2_3, dmin<ddim2>, dmax<ddim3>);
+        auto const derivs_min2_max3
+                = detail::strided_to_discrete_domain_chunkspan(derivs_min2_max3_strided);
         m_spline_builder1(
                 spline_derivs_min2_max3,
-                *mixed_derivs_min2_max3,
-                mixed_derivs_min1_min2_max3,
-                mixed_derivs_max1_min2_max3);
-    } else {
-        spline_derivs_min2_max3_opt = std::nullopt;
+                derivs_min2_max3,
+                detail::derivs(mixed_derivs1_2_3, dmin<ddim2>, dmax<ddim3>));
     }
 
-    ddc::Chunk spline_derivs_max2_min3_alloc(
-            m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain2_3),
-            ddc::KokkosAllocator<double, MemorySpace>());
-    auto spline_derivs_max2_min3 = spline_derivs_max2_min3_alloc.span_view();
-    auto spline_derivs_max2_min3_opt = std::optional(spline_derivs_max2_min3.span_cview());
     if constexpr (BcUpper2 == ddc::BoundCond::HERMITE || BcLower3 == ddc::BoundCond::HERMITE) {
+        auto const spline_derivs_max2_min3_strided
+                = detail::derivs(spline_derivs2_3, dmax<ddim2>, dmin<ddim3>);
+        auto const spline_derivs_max2_min3
+                = detail::strided_to_discrete_domain_chunkspan(spline_derivs_max2_min3_strided);
+
+        auto const derivs_max2_min3_strided
+                = detail::derivs(mixed_derivs2_3, dmax<ddim2>, dmin<ddim3>);
+        auto const derivs_max2_min3
+                = detail::strided_to_discrete_domain_chunkspan(derivs_max2_min3_strided);
         m_spline_builder1(
                 spline_derivs_max2_min3,
-                *mixed_derivs_max2_min3,
-                mixed_derivs_min1_max2_min3,
-                mixed_derivs_max1_max2_min3);
-    } else {
-        spline_derivs_max2_min3_opt = std::nullopt;
+                derivs_max2_min3,
+                detail::derivs(mixed_derivs1_2_3, dmax<ddim2>, dmin<ddim3>));
     }
 
-    ddc::Chunk spline_derivs_max2_max3_alloc(
-            m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain2_3),
-            ddc::KokkosAllocator<double, MemorySpace>());
-    auto spline_derivs_max2_max3 = spline_derivs_max2_max3_alloc.span_view();
-    auto spline_derivs_max2_max3_opt = std::optional(spline_derivs_max2_max3.span_cview());
     if constexpr (BcUpper2 == ddc::BoundCond::HERMITE || BcUpper3 == ddc::BoundCond::HERMITE) {
+        auto const spline_derivs_max2_max3_strided
+                = detail::derivs(spline_derivs2_3, dmax<ddim2>, dmax<ddim3>);
+        auto const spline_derivs_max2_max3
+                = detail::strided_to_discrete_domain_chunkspan(spline_derivs_max2_max3_strided);
+
+        auto const derivs_max2_max3_strided
+                = detail::derivs(mixed_derivs2_3, dmax<ddim2>, dmax<ddim3>);
+        auto const derivs_max2_max3
+                = detail::strided_to_discrete_domain_chunkspan(derivs_max2_max3_strided);
         m_spline_builder1(
                 spline_derivs_max2_max3,
-                *mixed_derivs_max2_max3,
-                mixed_derivs_min1_max2_max3,
-                mixed_derivs_max1_max2_max3);
-    } else {
-        spline_derivs_max2_max3_opt = std::nullopt;
+                derivs_max2_max3,
+                detail::derivs(mixed_derivs1_2_3, dmax<ddim2>, dmax<ddim3>));
     }
 
     // Spline1-approximate vals (to spline1)
@@ -1048,19 +942,14 @@ operator()(
             ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan const spline1 = spline1_alloc.span_view();
 
-    m_spline_builder1(spline1, vals, derivs_min1, derivs_max1);
+    m_spline_builder1(spline1, vals, derivs1);
 
     m_spline_builder_2_3(
             spline,
             spline1.span_cview(),
-            spline_derivs_min2_opt,
-            spline_derivs_max2_opt,
-            spline_derivs_min3_opt,
-            spline_derivs_max3_opt,
-            spline_derivs_min2_min3_opt,
-            spline_derivs_max2_min3_opt,
-            spline_derivs_min2_max3_opt,
-            spline_derivs_max2_max3_opt);
+            spline_derivs2.span_cview(),
+            spline_derivs3.span_cview(),
+            spline_derivs2_3.span_cview());
 }
 
 } // namespace ddc

--- a/include/ddc/kernels/splines/spline_builder_3d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_3d.hpp
@@ -193,7 +193,7 @@ public:
     /**
      * @brief The type of the whole Derivs domain (1D dimension of interest and cartesian
      * product of 1D Deriv domain and batch domain) in the first dimension, to be passed as
-     * argument to the buider, preserving the underlying memory layout (order of dimensions).
+     * argument to the builder, preserving the underlying memory layout (order of dimensions).
      *
      * @tparam The batched discrete domain on which the interpolation points are defined.
      *
@@ -228,7 +228,7 @@ public:
     /**
      * @brief The type of the whole Derivs domain (1D dimension of interest and cartesian
      * product of 1D Deriv domain and batch domain) in the second dimension, to be passed as
-     * argument to the buider, preserving the underlying memory layout (order of dimensions).
+     * argument to the builder, preserving the underlying memory layout (order of dimensions).
      *
      * @tparam The batched discrete domain on which the interpolation points are defined.
      *
@@ -263,7 +263,7 @@ public:
     /**
      * @brief The type of the whole Derivs domain (1D dimension of interest and cartesian
      * product of 1D Deriv domain and batch domain) in the third dimension, to be passed as
-     * argument to the buider, preserving the underlying memory layout (order of dimensions).
+     * argument to the builder, preserving the underlying memory layout (order of dimensions).
      *
      * @tparam The batched discrete domain on which the interpolation points are defined.
      *

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -183,25 +183,28 @@ void Batched2dSplineTest()
             dom_vals(dom_vals_tmp, interpolation_domain1, interpolation_domain2);
 
     // Create the derivs domain
+    int const nbc_i1 = s_degree / 2;
+    int const nbc_i2 = s_degree / 2;
+
     ddc::DiscreteDomain<ddc::Deriv<I1>> const
-            derivs_ddom1(DElem<ddc::Deriv<I1>>(1), DVect<ddc::Deriv<I1>>(s_degree / 2));
+            derivs_ddom1(DElem<ddc::Deriv<I1>>(1), DVect<ddc::Deriv<I1>>(nbc_i1));
     ddc::DiscreteDomain<ddc::Deriv<I2>> const
-            derivs_ddom2(DElem<ddc::Deriv<I2>>(1), DVect<ddc::Deriv<I2>>(s_degree / 2));
+            derivs_ddom2(DElem<ddc::Deriv<I2>>(1), DVect<ddc::Deriv<I2>>(nbc_i2));
     ddc::DiscreteDomain<ddc::Deriv<I1>, ddc::Deriv<I2>> const
             derivs_ddom(derivs_ddom1, derivs_ddom2);
 
     ddc::StridedDiscreteDomain<ddc::Deriv<I1>, ddc::Deriv<I2>> const derivs_domain(
             DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(1, 1),
-            DVect<ddc::Deriv<I1>, ddc::Deriv<I2>>(s_degree / 2, s_degree / 2),
+            DVect<ddc::Deriv<I1>, ddc::Deriv<I2>>(nbc_i1, nbc_i2),
             DVect<ddc::Deriv<I1>, ddc::Deriv<I2>>(1, 1));
 
     auto const whole_derivs_domain1 = ddc::detail::get_whole_derivs_domain<
-            ddc::Deriv<I1>>(interpolation_domain1, dom_vals, s_degree);
+            ddc::Deriv<I1>>(interpolation_domain1, dom_vals, nbc_i1);
     auto const whole_derivs_domain2 = ddc::detail::get_whole_derivs_domain<
-            ddc::Deriv<I2>>(interpolation_domain2, dom_vals, s_degree);
+            ddc::Deriv<I2>>(interpolation_domain2, dom_vals, nbc_i2);
     auto const whole_derivs_domain = ddc::detail::get_whole_derivs_domain<
             ddc::Deriv<I1>,
-            ddc::Deriv<I2>>(interpolation_domain, dom_vals, s_degree);
+            ddc::Deriv<I2>>(interpolation_domain, dom_vals, nbc_i1, nbc_i2);
 
     auto const dom_derivs = ddc::remove_dims_of<DDimI1, DDimI2>(whole_derivs_domain);
 

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -4,9 +4,7 @@
 
 #include <algorithm>
 #include <cstddef>
-#if defined(BC_HERMITE)
-#    include <optional>
-#endif
+
 #if defined(BSPLINES_TYPE_UNIFORM)
 #    include <type_traits>
 #endif
@@ -184,21 +182,28 @@ void Batched2dSplineTest()
     ddc::DiscreteDomain<DDims...> const
             dom_vals(dom_vals_tmp, interpolation_domain1, interpolation_domain2);
 
-#if defined(BC_HERMITE)
     // Create the derivs domain
     ddc::DiscreteDomain<ddc::Deriv<I1>> const
-            derivs_domain1(DElem<ddc::Deriv<I1>>(1), DVect<ddc::Deriv<I1>>(s_degree / 2));
+            derivs_ddom1(DElem<ddc::Deriv<I1>>(1), DVect<ddc::Deriv<I1>>(s_degree / 2));
     ddc::DiscreteDomain<ddc::Deriv<I2>> const
-            derivs_domain2(DElem<ddc::Deriv<I2>>(1), DVect<ddc::Deriv<I2>>(s_degree / 2));
+            derivs_ddom2(DElem<ddc::Deriv<I2>>(1), DVect<ddc::Deriv<I2>>(s_degree / 2));
     ddc::DiscreteDomain<ddc::Deriv<I1>, ddc::Deriv<I2>> const
-            derivs_domain(derivs_domain1, derivs_domain2);
+            derivs_ddom(derivs_ddom1, derivs_ddom2);
 
-    auto const dom_derivs_1d
-            = ddc::replace_dim_of<DDimI1, ddc::Deriv<I1>>(dom_vals, derivs_domain1);
-    auto const dom_derivs2 = ddc::replace_dim_of<DDimI2, ddc::Deriv<I2>>(dom_vals, derivs_domain2);
-    auto const dom_derivs
-            = ddc::replace_dim_of<DDimI2, ddc::Deriv<I2>>(dom_derivs_1d, derivs_domain2);
-#endif
+    ddc::StridedDiscreteDomain<ddc::Deriv<I1>, ddc::Deriv<I2>> const derivs_domain(
+            DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(1, 1),
+            DVect<ddc::Deriv<I1>, ddc::Deriv<I2>>(s_degree / 2, s_degree / 2),
+            DVect<ddc::Deriv<I1>, ddc::Deriv<I2>>(1, 1));
+
+    auto const whole_derivs_domain1 = ddc::detail::get_whole_derivs_domain<
+            ddc::Deriv<I1>>(interpolation_domain1, dom_vals, s_degree);
+    auto const whole_derivs_domain2 = ddc::detail::get_whole_derivs_domain<
+            ddc::Deriv<I2>>(interpolation_domain2, dom_vals, s_degree);
+    auto const whole_derivs_domain = ddc::detail::get_whole_derivs_domain<
+            ddc::Deriv<I1>,
+            ddc::Deriv<I2>>(interpolation_domain, dom_vals, s_degree);
+
+    auto const dom_derivs = ddc::remove_dims_of<DDimI1, DDimI2>(whole_derivs_domain);
 
     // Create a SplineBuilder over BSplines<I> and batched along other dimensions using some boundary conditions
     ddc::SplineBuilder2D<
@@ -236,141 +241,156 @@ void Batched2dSplineTest()
                 vals(e) = vals_1d(DElem<DDimI1, DDimI2>(e));
             });
 
-#if defined(BC_HERMITE)
     // Allocate and fill a chunk containing derivs to be passed as input to spline_builder.
     int const shift = s_degree % 2; // shift = 0 for even order, 1 for odd order
-    ddc::Chunk derivs_1d_lhs_alloc(dom_derivs_1d, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_1d_lhs = derivs_1d_lhs_alloc.span_view();
+
+    ddc::Chunk derivs1_alloc(whole_derivs_domain1, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::ChunkSpan const derivs1 = derivs1_alloc.span_view();
+
     if (s_bcl == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs_1d_lhs1_host_alloc(
-                ddc::DiscreteDomain<ddc::Deriv<I1>, DDimI2>(derivs_domain1, interpolation_domain2),
+        ddc::ChunkSpan const derivs1_lhs_view
+                = ddc::detail::derivs(derivs1, ddc::detail::dmin<DDimI1>);
+
+        ddc::Chunk derivs1_lhs_host_alloc(
+                ddc::DiscreteDomain<ddc::Deriv<I1>, DDimI2>(derivs_ddom1, interpolation_domain2),
                 ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_1d_lhs1_host = derivs_1d_lhs1_host_alloc.span_view();
+        ddc::ChunkSpan const derivs1_lhs_host = derivs1_lhs_host_alloc.span_view();
         ddc::for_each(
-                derivs_1d_lhs1_host.domain(),
+                derivs1_lhs_host.domain(),
                 KOKKOS_LAMBDA(ddc::DiscreteElement<ddc::Deriv<I1>, DDimI2> const e) {
                     auto deriv_idx = ddc::DiscreteElement<ddc::Deriv<I1>>(e).uid();
                     auto x2 = ddc::coordinate(ddc::DiscreteElement<DDimI2>(e));
-                    derivs_1d_lhs1_host(e)
-                            = evaluator.deriv(x0<I1>(), x2, deriv_idx + shift - 1, 0);
+                    derivs1_lhs_host(e) = evaluator.deriv(x0<I1>(), x2, deriv_idx + shift - 1, 0);
                 });
-        auto derivs_1d_lhs1_alloc
-                = ddc::create_mirror_view_and_copy(exec_space, derivs_1d_lhs1_host);
-        ddc::ChunkSpan const derivs_1d_lhs1 = derivs_1d_lhs1_alloc.span_view();
+        auto derivs1_lhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs1_lhs_host);
+        ddc::ChunkSpan const derivs1_lhs = derivs1_lhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
-                derivs_1d_lhs.domain(),
+                derivs1_lhs_view.domain(),
                 KOKKOS_LAMBDA(
-                        typename decltype(derivs_1d_lhs.domain())::discrete_element_type const e) {
-                    derivs_1d_lhs(e) = derivs_1d_lhs1(DElem<ddc::Deriv<I1>, DDimI2>(e));
+                        typename decltype(derivs1_lhs_view
+                                                  .domain())::discrete_element_type const e) {
+                    derivs1_lhs_view(e) = derivs1_lhs(DElem<ddc::Deriv<I1>, DDimI2>(e));
                 });
     }
 
-    ddc::Chunk derivs_1d_rhs_alloc(dom_derivs_1d, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_1d_rhs = derivs_1d_rhs_alloc.span_view();
-    if (s_bcl == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs_1d_rhs1_host_alloc(
-                ddc::DiscreteDomain<ddc::Deriv<I1>, DDimI2>(derivs_domain1, interpolation_domain2),
+    if (s_bcr == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs1_rhs_view
+                = ddc::detail::derivs(derivs1, ddc::detail::dmax<DDimI1>);
+
+        ddc::Chunk derivs1_rhs_host_alloc(
+                ddc::DiscreteDomain<ddc::Deriv<I1>, DDimI2>(derivs_ddom1, interpolation_domain2),
                 ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_1d_rhs1_host = derivs_1d_rhs1_host_alloc.span_view();
+        ddc::ChunkSpan const derivs1_rhs_host = derivs1_rhs_host_alloc.span_view();
         ddc::for_each(
-                derivs_1d_rhs1_host.domain(),
+                derivs1_rhs_host.domain(),
                 KOKKOS_LAMBDA(ddc::DiscreteElement<ddc::Deriv<I1>, DDimI2> const e) {
                     auto deriv_idx = ddc::DiscreteElement<ddc::Deriv<I1>>(e).uid();
                     auto x2 = ddc::coordinate(ddc::DiscreteElement<DDimI2>(e));
-                    derivs_1d_rhs1_host(e)
-                            = evaluator.deriv(xN<I1>(), x2, deriv_idx + shift - 1, 0);
+                    derivs1_rhs_host(e) = evaluator.deriv(xN<I1>(), x2, deriv_idx + shift - 1, 0);
                 });
-        auto derivs_1d_rhs1_alloc
-                = ddc::create_mirror_view_and_copy(exec_space, derivs_1d_rhs1_host);
-        ddc::ChunkSpan const derivs_1d_rhs1 = derivs_1d_rhs1_alloc.span_view();
+        auto derivs1_rhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs1_rhs_host);
+        ddc::ChunkSpan const derivs1_rhs = derivs1_rhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
-                derivs_1d_rhs.domain(),
+                derivs1_rhs_view.domain(),
                 KOKKOS_LAMBDA(
-                        typename decltype(derivs_1d_rhs.domain())::discrete_element_type const e) {
-                    derivs_1d_rhs(e) = derivs_1d_rhs1(DElem<ddc::Deriv<I1>, DDimI2>(e));
+                        typename decltype(derivs1_rhs_view
+                                                  .domain())::discrete_element_type const e) {
+                    derivs1_rhs_view(e) = derivs1_rhs(DElem<ddc::Deriv<I1>, DDimI2>(e));
                 });
     }
 
-    ddc::Chunk derivs2_lhs_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs2_lhs = derivs2_lhs_alloc.span_view();
+    ddc::Chunk derivs2_alloc(whole_derivs_domain2, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::ChunkSpan const derivs2 = derivs2_alloc.span_view();
+
     if (s_bcl == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs2_lhs1_host_alloc(
-                ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>>(interpolation_domain1, derivs_domain2),
+        ddc::ChunkSpan const derivs2_lhs_view
+                = ddc::detail::derivs(derivs2, ddc::detail::dmin<DDimI2>);
+
+        ddc::Chunk derivs2_lhs_host_alloc(
+                ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>>(interpolation_domain1, derivs_ddom2),
                 ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs2_lhs1_host = derivs2_lhs1_host_alloc.span_view();
+        ddc::ChunkSpan const derivs2_lhs_host = derivs2_lhs_host_alloc.span_view();
         ddc::for_each(
-                derivs2_lhs1_host.domain(),
+                derivs2_lhs_host.domain(),
                 KOKKOS_LAMBDA(ddc::DiscreteElement<DDimI1, ddc::Deriv<I2>> const e) {
                     auto x1 = ddc::coordinate(ddc::DiscreteElement<DDimI1>(e));
                     auto deriv_idx = ddc::DiscreteElement<ddc::Deriv<I2>>(e).uid();
-                    derivs2_lhs1_host(e) = evaluator.deriv(x1, x0<I2>(), 0, deriv_idx + shift - 1);
+                    derivs2_lhs_host(e) = evaluator.deriv(x1, x0<I2>(), 0, deriv_idx + shift - 1);
                 });
 
-        auto derivs2_lhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs2_lhs1_host);
-        ddc::ChunkSpan const derivs2_lhs1 = derivs2_lhs1_alloc.span_view();
+        auto derivs2_lhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs2_lhs_host);
+        ddc::ChunkSpan const derivs2_lhs = derivs2_lhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
-                derivs2_lhs.domain(),
+                derivs2_lhs_view.domain(),
                 KOKKOS_LAMBDA(
-                        typename decltype(derivs2_lhs.domain())::discrete_element_type const e) {
-                    derivs2_lhs(e) = derivs2_lhs1(DElem<DDimI1, ddc::Deriv<I2>>(e));
+                        typename decltype(derivs2_lhs_view
+                                                  .domain())::discrete_element_type const e) {
+                    derivs2_lhs_view(e) = derivs2_lhs(DElem<DDimI1, ddc::Deriv<I2>>(e));
                 });
     }
 
-    ddc::Chunk derivs2_rhs_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs2_rhs = derivs2_rhs_alloc.span_view();
-    if (s_bcl == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs2_rhs1_host_alloc(
-                ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>>(interpolation_domain1, derivs_domain2),
+    if (s_bcr == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs2_rhs_view
+                = ddc::detail::derivs(derivs2, ddc::detail::dmax<DDimI2>);
+
+        ddc::Chunk derivs2_rhs_host_alloc(
+                ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>>(interpolation_domain1, derivs_ddom2),
                 ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs2_rhs1_host = derivs2_rhs1_host_alloc.span_view();
+        ddc::ChunkSpan const derivs2_rhs_host = derivs2_rhs_host_alloc.span_view();
         ddc::for_each(
-                derivs2_rhs1_host.domain(),
+                derivs2_rhs_host.domain(),
                 KOKKOS_LAMBDA(ddc::DiscreteElement<DDimI1, ddc::Deriv<I2>> const e) {
                     auto x1 = ddc::coordinate(ddc::DiscreteElement<DDimI1>(e));
                     auto deriv_idx = ddc::DiscreteElement<ddc::Deriv<I2>>(e).uid();
-                    derivs2_rhs1_host(e) = evaluator.deriv(x1, xN<I2>(), 0, deriv_idx + shift - 1);
+                    derivs2_rhs_host(e) = evaluator.deriv(x1, xN<I2>(), 0, deriv_idx + shift - 1);
                 });
 
-        auto derivs2_rhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs2_rhs1_host);
-        ddc::ChunkSpan const derivs2_rhs1 = derivs2_rhs1_alloc.span_view();
+        auto derivs2_rhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs2_rhs_host);
+        ddc::ChunkSpan const derivs2_rhs = derivs2_rhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
-                derivs2_rhs.domain(),
+                derivs2_rhs_view.domain(),
                 KOKKOS_LAMBDA(
-                        typename decltype(derivs2_rhs.domain())::discrete_element_type const e) {
-                    derivs2_rhs(e) = derivs2_rhs1(DElem<DDimI1, ddc::Deriv<I2>>(e));
+                        typename decltype(derivs2_rhs_view
+                                                  .domain())::discrete_element_type const e) {
+                    derivs2_rhs_view(e) = derivs2_rhs(DElem<DDimI1, ddc::Deriv<I2>>(e));
                 });
     }
 
-    ddc::Chunk derivs_mixed_lhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs_lhs = derivs_mixed_lhs_lhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs_lhs = derivs_mixed_rhs_lhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_lhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs_rhs = derivs_mixed_lhs_rhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs_rhs = derivs_mixed_rhs_rhs_alloc.span_view();
+    ddc::Chunk derivs_mixed_1_2_alloc(
+            whole_derivs_domain,
+            ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::ChunkSpan const derivs_mixed_1_2 = derivs_mixed_1_2_alloc.span_view();
 
-    if (s_bcl == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_mixed_lhs_lhs1_host
-                = derivs_mixed_lhs_lhs1_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_mixed_rhs_lhs1_host
-                = derivs_mixed_rhs_lhs1_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_mixed_lhs_rhs1_host
-                = derivs_mixed_lhs_rhs1_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_mixed_rhs_rhs1_host
-                = derivs_mixed_rhs_rhs1_host_alloc.span_view();
+    if (s_bcl == ddc::BoundCond::HERMITE || s_bcr == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_view = ddc::detail::
+                derivs(derivs_mixed_1_2, ddc::detail::dmin<DDimI1>, ddc::detail::dmin<DDimI2>);
+        ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_view = ddc::detail::
+                derivs(derivs_mixed_1_2, ddc::detail::dmax<DDimI1>, ddc::detail::dmin<DDimI2>);
+        ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_view = ddc::detail::
+                derivs(derivs_mixed_1_2, ddc::detail::dmin<DDimI1>, ddc::detail::dmax<DDimI2>);
+        ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_view = ddc::detail::
+                derivs(derivs_mixed_1_2, ddc::detail::dmax<DDimI1>, ddc::detail::dmax<DDimI2>);
+
+        ddc::Chunk derivs_mixed_lhs1_lhs2_host_alloc(derivs_ddom, ddc::HostAllocator<double>());
+        ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_host
+                = derivs_mixed_lhs1_lhs2_host_alloc.span_view();
+        ddc::Chunk derivs_mixed_rhs1_lhs2_host_alloc(derivs_ddom, ddc::HostAllocator<double>());
+        ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_host
+                = derivs_mixed_rhs1_lhs2_host_alloc.span_view();
+        ddc::Chunk derivs_mixed_lhs1_rhs2_host_alloc(derivs_ddom, ddc::HostAllocator<double>());
+        ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_host
+                = derivs_mixed_lhs1_rhs2_host_alloc.span_view();
+        ddc::Chunk derivs_mixed_rhs1_rhs2_host_alloc(derivs_ddom, ddc::HostAllocator<double>());
+        ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_host
+                = derivs_mixed_rhs1_rhs2_host_alloc.span_view();
 
         for (std::size_t ii = 1;
              ii < static_cast<std::size_t>(derivs_domain.template extent<ddc::Deriv<I1>>()) + 1;
@@ -378,69 +398,59 @@ void Batched2dSplineTest()
             for (std::size_t jj = 1;
                  jj < static_cast<std::size_t>(derivs_domain.template extent<ddc::Deriv<I2>>()) + 1;
                  ++jj) {
-                derivs_mixed_lhs_lhs1_host(
+                derivs_mixed_lhs1_lhs2_host(
                         typename decltype(derivs_domain)::discrete_element_type(ii, jj))
                         = evaluator.deriv(x0<I1>(), x0<I2>(), ii + shift - 1, jj + shift - 1);
-                derivs_mixed_rhs_lhs1_host(
+                derivs_mixed_rhs1_lhs2_host(
                         typename decltype(derivs_domain)::discrete_element_type(ii, jj))
                         = evaluator.deriv(xN<I1>(), x0<I2>(), ii + shift - 1, jj + shift - 1);
-                derivs_mixed_lhs_rhs1_host(
+                derivs_mixed_lhs1_rhs2_host(
                         typename decltype(derivs_domain)::discrete_element_type(ii, jj))
                         = evaluator.deriv(x0<I1>(), xN<I2>(), ii + shift - 1, jj + shift - 1);
-                derivs_mixed_rhs_rhs1_host(
+                derivs_mixed_rhs1_rhs2_host(
                         typename decltype(derivs_domain)::discrete_element_type(ii, jj))
                         = evaluator.deriv(xN<I1>(), xN<I2>(), ii + shift - 1, jj + shift - 1);
             }
         }
-        auto derivs_mixed_lhs_lhs1_alloc
-                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_lhs_lhs1_host);
-        ddc::ChunkSpan const derivs_mixed_lhs_lhs1 = derivs_mixed_lhs_lhs1_alloc.span_view();
-        auto derivs_mixed_rhs_lhs1_alloc
-                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_rhs_lhs1_host);
-        ddc::ChunkSpan const derivs_mixed_rhs_lhs1 = derivs_mixed_rhs_lhs1_alloc.span_view();
-        auto derivs_mixed_lhs_rhs1_alloc
-                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_lhs_rhs1_host);
-        ddc::ChunkSpan const derivs_mixed_lhs_rhs1 = derivs_mixed_lhs_rhs1_alloc.span_view();
-        auto derivs_mixed_rhs_rhs1_alloc
-                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_rhs_rhs1_host);
-        ddc::ChunkSpan const derivs_mixed_rhs_rhs1 = derivs_mixed_rhs_rhs1_alloc.span_view();
+        auto derivs_mixed_lhs1_lhs2_alloc
+                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_lhs1_lhs2_host);
+        ddc::ChunkSpan const derivs_mixed_lhs1_lhs2 = derivs_mixed_lhs1_lhs2_alloc.span_view();
+        auto derivs_mixed_rhs1_lhs2_alloc
+                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_rhs1_lhs2_host);
+        ddc::ChunkSpan const derivs_mixed_rhs1_lhs2 = derivs_mixed_rhs1_lhs2_alloc.span_view();
+        auto derivs_mixed_lhs1_rhs2_alloc
+                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_lhs1_rhs2_host);
+        ddc::ChunkSpan const derivs_mixed_lhs1_rhs2 = derivs_mixed_lhs1_rhs2_alloc.span_view();
+        auto derivs_mixed_rhs1_rhs2_alloc
+                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_rhs1_rhs2_host);
+        ddc::ChunkSpan const derivs_mixed_rhs1_rhs2 = derivs_mixed_rhs1_rhs2_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
                 dom_derivs,
                 KOKKOS_LAMBDA(typename decltype(dom_derivs)::discrete_element_type const e) {
-                    derivs_mixed_lhs_lhs(e)
-                            = derivs_mixed_lhs_lhs1(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
-                    derivs_mixed_rhs_lhs(e)
-                            = derivs_mixed_rhs_lhs1(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
-                    derivs_mixed_lhs_rhs(e)
-                            = derivs_mixed_lhs_rhs1(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
-                    derivs_mixed_rhs_rhs(e)
-                            = derivs_mixed_rhs_rhs1(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
+                    derivs_mixed_lhs1_lhs2_view(e)
+                            = derivs_mixed_lhs1_lhs2(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
+                    derivs_mixed_rhs1_lhs2_view(e)
+                            = derivs_mixed_rhs1_lhs2(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
+                    derivs_mixed_lhs1_rhs2_view(e)
+                            = derivs_mixed_lhs1_rhs2(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
+                    derivs_mixed_rhs1_rhs2_view(e)
+                            = derivs_mixed_rhs1_rhs2(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
                 });
     }
-#endif
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
     ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
-#if defined(BC_HERMITE)
     spline_builder(
             coef,
             vals.span_cview(),
-            std::optional(derivs_1d_lhs.span_cview()),
-            std::optional(derivs_1d_rhs.span_cview()),
-            std::optional(derivs2_lhs.span_cview()),
-            std::optional(derivs2_rhs.span_cview()),
-            std::optional(derivs_mixed_lhs_lhs.span_cview()),
-            std::optional(derivs_mixed_rhs_lhs.span_cview()),
-            std::optional(derivs_mixed_lhs_rhs.span_cview()),
-            std::optional(derivs_mixed_rhs_rhs.span_cview()));
-#else
-    spline_builder(coef, vals.span_cview());
-#endif
+            derivs1.span_cview(),
+            derivs2.span_cview(),
+            derivs_mixed_1_2.span_cview());
 
     // Instantiate a SplineEvaluator over interest dimension and batched along other dimensions
 #if defined(BC_PERIODIC)

--- a/tests/splines/batched_3d_spline_builder.cpp
+++ b/tests/splines/batched_3d_spline_builder.cpp
@@ -208,14 +208,17 @@ void Batched3dSplineTest()
             interpolation_domain2,
             interpolation_domain3);
 
-#if defined(BC_HERMITE)
     // Create the derivs domain
+    int const nbc_i1 = s_degree / 2;
+    int const nbc_i2 = s_degree / 2;
+    int const nbc_i3 = s_degree / 2;
+
     ddc::DiscreteDomain<ddc::Deriv<I1>> const
-            derivs_domain1(DElem<ddc::Deriv<I1>>(1), DVect<ddc::Deriv<I1>>(s_degree / 2));
+            derivs_domain1(DElem<ddc::Deriv<I1>>(1), DVect<ddc::Deriv<I1>>(nbc_i1));
     ddc::DiscreteDomain<ddc::Deriv<I2>> const
-            derivs_domain2(DElem<ddc::Deriv<I2>>(1), DVect<ddc::Deriv<I2>>(s_degree / 2));
+            derivs_domain2(DElem<ddc::Deriv<I2>>(1), DVect<ddc::Deriv<I2>>(nbc_i2));
     ddc::DiscreteDomain<ddc::Deriv<I3>> const
-            derivs_domain3(DElem<ddc::Deriv<I3>>(1), DVect<ddc::Deriv<I3>>(s_degree / 2));
+            derivs_domain3(DElem<ddc::Deriv<I3>>(1), DVect<ddc::Deriv<I3>>(nbc_i3));
     ddc::DiscreteDomain<ddc::Deriv<I1>, ddc::Deriv<I2>, DDimI3> const
             derivs_domain12(derivs_domain1, derivs_domain2, interpolation_domain3);
     ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>, ddc::Deriv<I3>> const
@@ -236,7 +239,35 @@ void Batched3dSplineTest()
             = ddc::replace_dim_of<DDimI3, ddc::Deriv<I3>>(dom_derivs1, derivs_domain3);
     auto const dom_derivs_all
             = ddc::replace_dim_of<DDimI3, ddc::Deriv<I3>>(dom_derivs12, derivs_domain3);
-#endif
+
+    auto const whole_derivs_domain1 = ddc::detail::get_whole_derivs_domain<
+            ddc::Deriv<I1>>(interpolation_domain1, dom_vals, nbc_i1);
+    auto const whole_derivs_domain2 = ddc::detail::get_whole_derivs_domain<
+            ddc::Deriv<I2>>(interpolation_domain2, dom_vals, nbc_i2);
+    auto const whole_derivs_domain3 = ddc::detail::get_whole_derivs_domain<
+            ddc::Deriv<I3>>(interpolation_domain3, dom_vals, nbc_i3);
+    auto const whole_derivs_domain1_2
+            = ddc::detail::get_whole_derivs_domain<ddc::Deriv<I1>, ddc::Deriv<I2>>(
+                    ddc::select<DDimI1, DDimI2>(interpolation_domain),
+                    dom_vals,
+                    nbc_i1,
+                    nbc_i2);
+    auto const whole_derivs_domain2_3
+            = ddc::detail::get_whole_derivs_domain<ddc::Deriv<I2>, ddc::Deriv<I3>>(
+                    ddc::select<DDimI2, DDimI3>(interpolation_domain),
+                    dom_vals,
+                    nbc_i2,
+                    nbc_i3);
+    auto const whole_derivs_domain1_3
+            = ddc::detail::get_whole_derivs_domain<ddc::Deriv<I1>, ddc::Deriv<I3>>(
+                    ddc::select<DDimI1, DDimI3>(interpolation_domain),
+                    dom_vals,
+                    nbc_i1,
+                    nbc_i3);
+    auto const whole_derivs_domain = ddc::detail::get_whole_derivs_domain<
+            ddc::Deriv<I1>,
+            ddc::Deriv<I2>,
+            ddc::Deriv<I3>>(interpolation_domain, dom_vals, nbc_i1, nbc_i2, nbc_i3);
 
     // Create a SplineBuilder over BSplines<I> and batched along other dimensions using some boundary conditions
     ddc::SplineBuilder3D<
@@ -278,20 +309,23 @@ void Batched3dSplineTest()
                 vals(e) = vals_1d(DElem<DDimI1, DDimI2, DDimI3>(e));
             });
 
-#if defined(BC_HERMITE)
     // Allocate and fill a chunk containing derivs to be passed as input to spline_builder.
     int const shift = s_degree % 2; // shift = 0 for even order, 1 for odd order
 
-    ddc::Chunk derivs1_lhs_view_alloc(dom_derivs1, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs1_lhs_view = derivs1_lhs_view_alloc.span_view();
+    ddc::Chunk derivs1_alloc(whole_derivs_domain1, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::ChunkSpan const derivs1 = derivs1_alloc.span_view();
+
     if (s_bcl == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs1_lhs_host_alloc(
+        ddc::ChunkSpan const derivs1_lhs_view
+                = ddc::detail::derivs(derivs1, ddc::detail::dmin<DDimI1>);
+
+        ddc::Chunk derivs1_lhs1_host_alloc(
                 ddc::DiscreteDomain<
                         ddc::Deriv<I1>,
                         DDimI2,
                         DDimI3>(derivs_domain1, interpolation_domain2, interpolation_domain3),
                 ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs1_lhs_host = derivs1_lhs_host_alloc.span_view();
+        ddc::ChunkSpan const derivs1_lhs_host = derivs1_lhs1_host_alloc.span_view();
         ddc::for_each(
                 derivs1_lhs_host.domain(),
                 KOKKOS_LAMBDA(ddc::DiscreteElement<ddc::Deriv<I1>, DDimI2, DDimI3> const e) {
@@ -302,7 +336,7 @@ void Batched3dSplineTest()
                             = evaluator.deriv(x0<I1>(), x2, x3, deriv_idx + shift - 1, 0, 0);
                 });
         auto derivs1_lhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs1_lhs_host);
-        ddc::ChunkSpan const derivs1_lhs = derivs1_lhs_alloc.span_view();
+        ddc::ChunkSpan const derivs1_lhs1 = derivs1_lhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
@@ -310,20 +344,21 @@ void Batched3dSplineTest()
                 KOKKOS_LAMBDA(
                         typename decltype(derivs1_lhs_view
                                                   .domain())::discrete_element_type const e) {
-                    derivs1_lhs_view(e) = derivs1_lhs(DElem<ddc::Deriv<I1>, DDimI2, DDimI3>(e));
+                    derivs1_lhs_view(e) = derivs1_lhs1(DElem<ddc::Deriv<I1>, DDimI2, DDimI3>(e));
                 });
     }
 
-    ddc::Chunk derivs1_rhs_view_alloc(dom_derivs1, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs1_rhs_view = derivs1_rhs_view_alloc.span_view();
     if (s_bcr == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs1_rhs_host_alloc(
+        ddc::ChunkSpan const derivs1_rhs_view
+                = ddc::detail::derivs(derivs1, ddc::detail::dmax<DDimI1>);
+
+        ddc::Chunk derivs1_rhs1_host_alloc(
                 ddc::DiscreteDomain<
                         ddc::Deriv<I1>,
                         DDimI2,
                         DDimI3>(derivs_domain1, interpolation_domain2, interpolation_domain3),
                 ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs1_rhs_host = derivs1_rhs_host_alloc.span_view();
+        ddc::ChunkSpan const derivs1_rhs_host = derivs1_rhs1_host_alloc.span_view();
         ddc::for_each(
                 derivs1_rhs_host.domain(),
                 KOKKOS_LAMBDA(ddc::DiscreteElement<ddc::Deriv<I1>, DDimI2, DDimI3> const e) {
@@ -334,7 +369,7 @@ void Batched3dSplineTest()
                             = evaluator.deriv(xN<I1>(), x2, x3, deriv_idx + shift - 1, 0, 0);
                 });
         auto derivs1_rhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs1_rhs_host);
-        ddc::ChunkSpan const derivs1_rhs = derivs1_rhs_alloc.span_view();
+        ddc::ChunkSpan const derivs1_rhs1 = derivs1_rhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
@@ -342,13 +377,17 @@ void Batched3dSplineTest()
                 KOKKOS_LAMBDA(
                         typename decltype(derivs1_rhs_view
                                                   .domain())::discrete_element_type const e) {
-                    derivs1_rhs_view(e) = derivs1_rhs(DElem<ddc::Deriv<I1>, DDimI2, DDimI3>(e));
+                    derivs1_rhs_view(e) = derivs1_rhs1(DElem<ddc::Deriv<I1>, DDimI2, DDimI3>(e));
                 });
     }
 
-    ddc::Chunk derivs2_lhs_view_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs2_lhs_view = derivs2_lhs_view_alloc.span_view();
+    ddc::Chunk derivs2_alloc(whole_derivs_domain2, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::ChunkSpan const derivs2 = derivs2_alloc.span_view();
+
     if (s_bcl == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs2_lhs_view
+                = ddc::detail::derivs(derivs2, ddc::detail::dmin<DDimI2>);
+
         ddc::Chunk derivs2_lhs_host_alloc(
                 ddc::DiscreteDomain<
                         DDimI1,
@@ -379,9 +418,10 @@ void Batched3dSplineTest()
                 });
     }
 
-    ddc::Chunk derivs2_rhs_view_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs2_rhs_view = derivs2_rhs_view_alloc.span_view();
     if (s_bcr == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs2_rhs_view
+                = ddc::detail::derivs(derivs2, ddc::detail::dmax<DDimI2>);
+
         ddc::Chunk derivs2_rhs_host_alloc(
                 ddc::DiscreteDomain<
                         DDimI1,
@@ -412,9 +452,13 @@ void Batched3dSplineTest()
                 });
     }
 
-    ddc::Chunk derivs3_lhs_view_alloc(dom_derivs3, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs3_lhs_view = derivs3_lhs_view_alloc.span_view();
+    ddc::Chunk derivs3_alloc(whole_derivs_domain3, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::ChunkSpan const derivs3 = derivs3_alloc.span_view();
+
     if (s_bcl == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs3_lhs_view
+                = ddc::detail::derivs(derivs3, ddc::detail::dmin<DDimI3>);
+
         ddc::Chunk derivs3_lhs_host_alloc(
                 ddc::DiscreteDomain<
                         DDimI1,
@@ -446,9 +490,10 @@ void Batched3dSplineTest()
                 });
     }
 
-    ddc::Chunk derivs3_rhs_view_alloc(dom_derivs3, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs3_rhs_view = derivs3_rhs_view_alloc.span_view();
     if (s_bcr == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs3_rhs_view
+                = ddc::detail::derivs(derivs3, ddc::detail::dmax<DDimI3>);
+
         ddc::Chunk derivs3_rhs_host_alloc(
                 ddc::DiscreteDomain<
                         DDimI1,
@@ -480,28 +525,21 @@ void Batched3dSplineTest()
                 });
     }
 
-    ddc::Chunk derivs_mixed_lhs1_lhs2_view_alloc(
-            dom_derivs12,
+    ddc::Chunk derivs_mixed_1_2_alloc(
+            whole_derivs_domain1_2,
             ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_view
-            = derivs_mixed_lhs1_lhs2_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs1_lhs2_view_alloc(
-            dom_derivs12,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_view
-            = derivs_mixed_rhs1_lhs2_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_lhs1_rhs2_view_alloc(
-            dom_derivs12,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_view
-            = derivs_mixed_lhs1_rhs2_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs1_rhs2_view_alloc(
-            dom_derivs12,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_view
-            = derivs_mixed_rhs1_rhs2_view_alloc.span_view();
+    ddc::ChunkSpan const derivs_mixed_1_2 = derivs_mixed_1_2_alloc.span_view();
 
     if (s_bcl == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_view = ddc::detail::
+                derivs(derivs_mixed_1_2, ddc::detail::dmin<DDimI1>, ddc::detail::dmin<DDimI2>);
+        ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_view = ddc::detail::
+                derivs(derivs_mixed_1_2, ddc::detail::dmax<DDimI1>, ddc::detail::dmin<DDimI2>);
+        ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_view = ddc::detail::
+                derivs(derivs_mixed_1_2, ddc::detail::dmin<DDimI1>, ddc::detail::dmax<DDimI2>);
+        ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_view = ddc::detail::
+                derivs(derivs_mixed_1_2, ddc::detail::dmax<DDimI1>, ddc::detail::dmax<DDimI2>);
+
         ddc::Chunk derivs_mixed_lhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<double>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_host
                 = derivs_mixed_lhs1_lhs2_host_alloc.span_view();
@@ -580,28 +618,21 @@ void Batched3dSplineTest()
                 });
     }
 
-    ddc::Chunk derivs_mixed_lhs2_lhs3_view_alloc(
-            dom_derivs23,
+    ddc::Chunk derivs_mixed_2_3_alloc(
+            whole_derivs_domain2_3,
             ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs2_lhs3_view
-            = derivs_mixed_lhs2_lhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs2_lhs3_view_alloc(
-            dom_derivs23,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs2_lhs3_view
-            = derivs_mixed_rhs2_lhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_lhs2_rhs3_view_alloc(
-            dom_derivs23,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs2_rhs3_view
-            = derivs_mixed_lhs2_rhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs2_rhs3_view_alloc(
-            dom_derivs23,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs2_rhs3_view
-            = derivs_mixed_rhs2_rhs3_view_alloc.span_view();
+    ddc::ChunkSpan const derivs_mixed_2_3 = derivs_mixed_2_3_alloc.span_view();
 
     if (s_bcl == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs_mixed_lhs2_lhs3_view = ddc::detail::
+                derivs(derivs_mixed_2_3, ddc::detail::dmin<DDimI2>, ddc::detail::dmin<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_rhs2_lhs3_view = ddc::detail::
+                derivs(derivs_mixed_2_3, ddc::detail::dmax<DDimI2>, ddc::detail::dmin<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_lhs2_rhs3_view = ddc::detail::
+                derivs(derivs_mixed_2_3, ddc::detail::dmin<DDimI2>, ddc::detail::dmax<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_rhs2_rhs3_view = ddc::detail::
+                derivs(derivs_mixed_2_3, ddc::detail::dmax<DDimI2>, ddc::detail::dmax<DDimI3>);
+
         ddc::Chunk derivs_mixed_lhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<double>());
         ddc::ChunkSpan const derivs_mixed_lhs2_lhs3_host
                 = derivs_mixed_lhs2_lhs3_host_alloc.span_view();
@@ -680,28 +711,21 @@ void Batched3dSplineTest()
                 });
     }
 
-    ddc::Chunk derivs_mixed_lhs1_lhs3_view_alloc(
-            dom_derivs13,
+    ddc::Chunk derivs_mixed_1_3_alloc(
+            whole_derivs_domain1_3,
             ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs1_lhs3_view
-            = derivs_mixed_lhs1_lhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs1_lhs3_view_alloc(
-            dom_derivs13,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs1_lhs3_view
-            = derivs_mixed_rhs1_lhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_lhs1_rhs3_view_alloc(
-            dom_derivs13,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs1_rhs3_view
-            = derivs_mixed_lhs1_rhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs1_rhs3_view_alloc(
-            dom_derivs13,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs1_rhs3_view
-            = derivs_mixed_rhs1_rhs3_view_alloc.span_view();
+    ddc::ChunkSpan const derivs_mixed_1_3 = derivs_mixed_1_3_alloc.span_view();
 
     if (s_bcl == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs_mixed_lhs1_lhs3_view = ddc::detail::
+                derivs(derivs_mixed_1_3, ddc::detail::dmin<DDimI1>, ddc::detail::dmin<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_rhs1_lhs3_view = ddc::detail::
+                derivs(derivs_mixed_1_3, ddc::detail::dmax<DDimI1>, ddc::detail::dmin<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_lhs1_rhs3_view = ddc::detail::
+                derivs(derivs_mixed_1_3, ddc::detail::dmin<DDimI1>, ddc::detail::dmax<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_rhs1_rhs3_view = ddc::detail::
+                derivs(derivs_mixed_1_3, ddc::detail::dmax<DDimI1>, ddc::detail::dmax<DDimI3>);
+
         ddc::Chunk derivs_mixed_lhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<double>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs3_host
                 = derivs_mixed_lhs1_lhs3_host_alloc.span_view();
@@ -780,48 +804,53 @@ void Batched3dSplineTest()
                 });
     }
 
-    ddc::Chunk derivs_mixed_lhs1_lhs2_lhs3_view_alloc(
-            dom_derivs_all,
+    ddc::Chunk derivs_mixed_1_2_3_alloc(
+            whole_derivs_domain,
             ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_lhs3_view
-            = derivs_mixed_lhs1_lhs2_lhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs1_lhs2_lhs3_view_alloc(
-            dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_lhs3_view
-            = derivs_mixed_rhs1_lhs2_lhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_lhs1_rhs2_lhs3_view_alloc(
-            dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_lhs3_view
-            = derivs_mixed_lhs1_rhs2_lhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs1_rhs2_lhs3_view_alloc(
-            dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_lhs3_view
-            = derivs_mixed_rhs1_rhs2_lhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_lhs1_lhs2_rhs3_view_alloc(
-            dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_rhs3_view
-            = derivs_mixed_lhs1_lhs2_rhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs1_lhs2_rhs3_view_alloc(
-            dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_rhs3_view
-            = derivs_mixed_rhs1_lhs2_rhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_lhs1_rhs2_rhs3_view_alloc(
-            dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_rhs3_view
-            = derivs_mixed_lhs1_rhs2_rhs3_view_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs1_rhs2_rhs3_view_alloc(
-            dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_rhs3_view
-            = derivs_mixed_rhs1_rhs2_rhs3_view_alloc.span_view();
+    ddc::ChunkSpan const derivs_mixed_1_2_3 = derivs_mixed_1_2_3_alloc.span_view();
 
-    if (s_bcl == ddc::BoundCond::HERMITE) {
+    if (s_bcl == ddc::BoundCond::HERMITE || s_bcr == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_lhs3_view = ddc::detail::
+                derivs(derivs_mixed_1_2_3,
+                       ddc::detail::dmin<DDimI1>,
+                       ddc::detail::dmin<DDimI2>,
+                       ddc::detail::dmin<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_lhs3_view = ddc::detail::
+                derivs(derivs_mixed_1_2_3,
+                       ddc::detail::dmax<DDimI1>,
+                       ddc::detail::dmin<DDimI2>,
+                       ddc::detail::dmin<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_lhs3_view = ddc::detail::
+                derivs(derivs_mixed_1_2_3,
+                       ddc::detail::dmin<DDimI1>,
+                       ddc::detail::dmax<DDimI2>,
+                       ddc::detail::dmin<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_lhs3_view = ddc::detail::
+                derivs(derivs_mixed_1_2_3,
+                       ddc::detail::dmax<DDimI1>,
+                       ddc::detail::dmax<DDimI2>,
+                       ddc::detail::dmin<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_rhs3_view = ddc::detail::
+                derivs(derivs_mixed_1_2_3,
+                       ddc::detail::dmin<DDimI1>,
+                       ddc::detail::dmin<DDimI2>,
+                       ddc::detail::dmax<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_rhs3_view = ddc::detail::
+                derivs(derivs_mixed_1_2_3,
+                       ddc::detail::dmax<DDimI1>,
+                       ddc::detail::dmin<DDimI2>,
+                       ddc::detail::dmax<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_rhs3_view = ddc::detail::
+                derivs(derivs_mixed_1_2_3,
+                       ddc::detail::dmin<DDimI1>,
+                       ddc::detail::dmax<DDimI2>,
+                       ddc::detail::dmax<DDimI3>);
+        ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_rhs3_view = ddc::detail::
+                derivs(derivs_mixed_1_2_3,
+                       ddc::detail::dmax<DDimI1>,
+                       ddc::detail::dmax<DDimI2>,
+                       ddc::detail::dmax<DDimI3>);
+
         ddc::Chunk derivs_mixed_lhs1_lhs2_lhs3_host_alloc(
                 derivs_domain_all,
                 ddc::HostAllocator<double>());
@@ -1005,48 +1034,24 @@ void Batched3dSplineTest()
                             DElem<ddc::Deriv<I1>, ddc::Deriv<I2>, ddc::Deriv<I3>>(e));
                 });
     }
-#endif
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
     ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
-#if defined(BC_HERMITE)
     spline_builder(
             coef,
             vals.span_cview(),
-            std::optional(derivs1_lhs_view.span_cview()),
-            std::optional(derivs1_rhs_view.span_cview()),
-            std::optional(derivs2_lhs_view.span_cview()),
-            std::optional(derivs2_rhs_view.span_cview()),
-            std::optional(derivs3_lhs_view.span_cview()),
-            std::optional(derivs3_rhs_view.span_cview()),
-            std::optional(derivs_mixed_lhs1_lhs2_view.span_cview()),
-            std::optional(derivs_mixed_rhs1_lhs2_view.span_cview()),
-            std::optional(derivs_mixed_lhs1_rhs2_view.span_cview()),
-            std::optional(derivs_mixed_rhs1_rhs2_view.span_cview()),
-            std::optional(derivs_mixed_lhs2_lhs3_view.span_cview()),
-            std::optional(derivs_mixed_rhs2_lhs3_view.span_cview()),
-            std::optional(derivs_mixed_lhs2_rhs3_view.span_cview()),
-            std::optional(derivs_mixed_rhs2_rhs3_view.span_cview()),
-            std::optional(derivs_mixed_lhs1_lhs3_view.span_cview()),
-            std::optional(derivs_mixed_rhs1_lhs3_view.span_cview()),
-            std::optional(derivs_mixed_lhs1_rhs3_view.span_cview()),
-            std::optional(derivs_mixed_rhs1_rhs3_view.span_cview()),
-            std::optional(derivs_mixed_lhs1_lhs2_lhs3_view.span_cview()),
-            std::optional(derivs_mixed_rhs1_lhs2_lhs3_view.span_cview()),
-            std::optional(derivs_mixed_lhs1_rhs2_lhs3_view.span_cview()),
-            std::optional(derivs_mixed_rhs1_rhs2_lhs3_view.span_cview()),
-            std::optional(derivs_mixed_lhs1_lhs2_rhs3_view.span_cview()),
-            std::optional(derivs_mixed_rhs1_lhs2_rhs3_view.span_cview()),
-            std::optional(derivs_mixed_lhs1_rhs2_rhs3_view.span_cview()),
-            std::optional(derivs_mixed_rhs1_rhs2_rhs3_view.span_cview()));
-#else
-    spline_builder(coef, vals.span_cview());
-#endif
+            derivs1.span_cview(),
+            derivs2.span_cview(),
+            derivs3.span_cview(),
+            derivs_mixed_1_2.span_cview(),
+            derivs_mixed_2_3.span_cview(),
+            derivs_mixed_1_3.span_cview(),
+            derivs_mixed_1_2_3.span_cview());
 
-    // Instantiate a SplineEvaluator over interest dimension and batched along other dimensions
+// Instantiate a SplineEvaluator over interest dimension and batched along other dimensions
 #if defined(BC_PERIODIC)
     using extrapolation_rule_1_type = ddc::PeriodicExtrapolationRule<I1>;
     using extrapolation_rule_2_type = ddc::PeriodicExtrapolationRule<I2>;

--- a/tests/splines/batched_3d_spline_builder.cpp
+++ b/tests/splines/batched_3d_spline_builder.cpp
@@ -236,7 +236,7 @@ void Batched3dSplineTest()
     auto const dom_derivs23
             = ddc::replace_dim_of<DDimI3, ddc::Deriv<I3>>(dom_derivs2, derivs_domain3);
     auto const dom_derivs13
-            = ddc::replace_dim_of<DDimI3, ddc::Deriv<I3>>(dom_derivs1, derivs_domain3);
+            = ddc::replace_dim_of<DDimI1, ddc::Deriv<I1>>(dom_derivs3, derivs_domain1);
     auto const dom_derivs_all
             = ddc::replace_dim_of<DDimI3, ddc::Deriv<I3>>(dom_derivs12, derivs_domain3);
 

--- a/tests/splines/batched_3d_spline_builder.cpp
+++ b/tests/splines/batched_3d_spline_builder.cpp
@@ -319,13 +319,13 @@ void Batched3dSplineTest()
         ddc::ChunkSpan const derivs1_lhs_view
                 = ddc::detail::derivs(derivs1, ddc::detail::dmin<DDimI1>);
 
-        ddc::Chunk derivs1_lhs1_host_alloc(
+        ddc::Chunk derivs1_lhs_host_alloc(
                 ddc::DiscreteDomain<
                         ddc::Deriv<I1>,
                         DDimI2,
                         DDimI3>(derivs_domain1, interpolation_domain2, interpolation_domain3),
                 ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs1_lhs_host = derivs1_lhs1_host_alloc.span_view();
+        ddc::ChunkSpan const derivs1_lhs_host = derivs1_lhs_host_alloc.span_view();
         ddc::for_each(
                 derivs1_lhs_host.domain(),
                 KOKKOS_LAMBDA(ddc::DiscreteElement<ddc::Deriv<I1>, DDimI2, DDimI3> const e) {
@@ -336,7 +336,7 @@ void Batched3dSplineTest()
                             = evaluator.deriv(x0<I1>(), x2, x3, deriv_idx + shift - 1, 0, 0);
                 });
         auto derivs1_lhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs1_lhs_host);
-        ddc::ChunkSpan const derivs1_lhs1 = derivs1_lhs_alloc.span_view();
+        ddc::ChunkSpan const derivs1_lhs = derivs1_lhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
@@ -344,7 +344,7 @@ void Batched3dSplineTest()
                 KOKKOS_LAMBDA(
                         typename decltype(derivs1_lhs_view
                                                   .domain())::discrete_element_type const e) {
-                    derivs1_lhs_view(e) = derivs1_lhs1(DElem<ddc::Deriv<I1>, DDimI2, DDimI3>(e));
+                    derivs1_lhs_view(e) = derivs1_lhs(DElem<ddc::Deriv<I1>, DDimI2, DDimI3>(e));
                 });
     }
 
@@ -352,13 +352,13 @@ void Batched3dSplineTest()
         ddc::ChunkSpan const derivs1_rhs_view
                 = ddc::detail::derivs(derivs1, ddc::detail::dmax<DDimI1>);
 
-        ddc::Chunk derivs1_rhs1_host_alloc(
+        ddc::Chunk derivs1_rhs_host_alloc(
                 ddc::DiscreteDomain<
                         ddc::Deriv<I1>,
                         DDimI2,
                         DDimI3>(derivs_domain1, interpolation_domain2, interpolation_domain3),
                 ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs1_rhs_host = derivs1_rhs1_host_alloc.span_view();
+        ddc::ChunkSpan const derivs1_rhs_host = derivs1_rhs_host_alloc.span_view();
         ddc::for_each(
                 derivs1_rhs_host.domain(),
                 KOKKOS_LAMBDA(ddc::DiscreteElement<ddc::Deriv<I1>, DDimI2, DDimI3> const e) {
@@ -369,7 +369,7 @@ void Batched3dSplineTest()
                             = evaluator.deriv(xN<I1>(), x2, x3, deriv_idx + shift - 1, 0, 0);
                 });
         auto derivs1_rhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs1_rhs_host);
-        ddc::ChunkSpan const derivs1_rhs1 = derivs1_rhs_alloc.span_view();
+        ddc::ChunkSpan const derivs1_rhs = derivs1_rhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
@@ -377,7 +377,7 @@ void Batched3dSplineTest()
                 KOKKOS_LAMBDA(
                         typename decltype(derivs1_rhs_view
                                                   .domain())::discrete_element_type const e) {
-                    derivs1_rhs_view(e) = derivs1_rhs1(DElem<ddc::Deriv<I1>, DDimI2, DDimI3>(e));
+                    derivs1_rhs_view(e) = derivs1_rhs(DElem<ddc::Deriv<I1>, DDimI2, DDimI3>(e));
                 });
     }
 

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) The DDC development team, see COPYRIGHT.md file
+// Copyright (C) The DDC development team, see COPYRIGHT.md filebatched
 //
 // SPDX-License-Identifier: MIT
 
@@ -204,8 +204,9 @@ void BatchedSplineTest()
     ddc::Chunk derivs_alloc(whole_derivs_domain, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan const derivs = derivs_alloc.span_view();
 
-    ddc::ChunkSpan const derivs_lhs_view = derivs[interpolation_domain.front()];
     if (s_bcl == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs_lhs_view = derivs[interpolation_domain.front()];
+
         ddc::Chunk derivs_lhs_host_alloc(derivs_domain, ddc::HostAllocator<double>());
         ddc::ChunkSpan const derivs_lhs_host = derivs_lhs_host_alloc.span_view();
         for (int ii = 1; ii < derivs_lhs_host.domain().template extent<ddc::Deriv<I>>() + 1; ++ii) {
@@ -222,8 +223,9 @@ void BatchedSplineTest()
                                 e) { derivs_lhs_view(e) = derivs_lhs(DElem<ddc::Deriv<I>>(e)); });
     }
 
-    ddc::ChunkSpan const derivs_rhs_view = derivs[interpolation_domain.front()];
     if (s_bcr == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs_rhs_view = derivs[interpolation_domain.back()];
+
         ddc::Chunk derivs_rhs_host_alloc(derivs_domain, ddc::HostAllocator<double>());
         ddc::ChunkSpan const derivs_rhs_host = derivs_rhs_host_alloc.span_view();
         for (int ii = 1; ii < derivs_rhs_host.domain().template extent<ddc::Deriv<I>>() + 1; ++ii) {

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -170,7 +170,7 @@ void BatchedSplineTest()
             ddc::Deriv<I>>(ddc::detail::to_strided_ddom(dom_vals), derivs_domain);
 
     auto const whole_derivs_domain = ddc::detail::get_whole_derivs_domain<
-            ddc::Deriv<I>>(interpolation_domain, dom_vals, s_degree_x);
+            ddc::Deriv<I>>(interpolation_domain, dom_vals, s_degree_x / 2);
 
     // Create a SplineBuilder over BSplines<I> and batched along other dimensions using some boundary conditions
     ddc::SplineBuilder<

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -165,11 +165,12 @@ void BatchedSplineTest()
             DElem<ddc::Deriv<I>>(1),
             DVect<ddc::Deriv<I>>(s_degree_x / 2),
             DVect<ddc::Deriv<I>>(1));
-    ddc::StridedDiscreteDomain<ddc::Deriv<I>, DDims...>
-            whole_derivs_domain(derivs_domain, ddc::detail::to_strided_ddom(dom_vals));
     auto const dom_derivs = ddc::replace_dim_of<
             DDimI,
             ddc::Deriv<I>>(ddc::detail::to_strided_ddom(dom_vals), derivs_domain);
+
+    auto const whole_derivs_domain = ddc::detail::get_whole_derivs_domain<
+            ddc::Deriv<I>>(interpolation_domain, dom_vals, s_degree_x);
 
     // Create a SplineBuilder over BSplines<I> and batched along other dimensions using some boundary conditions
     ddc::SplineBuilder<
@@ -206,8 +207,7 @@ void BatchedSplineTest()
     ddc::Chunk derivs_alloc(whole_derivs_domain, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan const derivs = derivs_alloc.span_view();
 
-    ddc::ChunkSpan const derivs_lhs_view
-            = derivs[ddc::DiscreteElement<DDimI>(derivs.domain().front())];
+    ddc::ChunkSpan const derivs_lhs_view = derivs[interpolation_domain.front()];
     if (s_bcl == ddc::BoundCond::HERMITE) {
         ddc::Chunk derivs_lhs_host_alloc(derivs_domain, ddc::HostAllocator<double>());
         ddc::ChunkSpan const derivs_lhs_host = derivs_lhs_host_alloc.span_view();
@@ -225,8 +225,7 @@ void BatchedSplineTest()
                                 e) { derivs_lhs_view(e) = derivs_lhs(DElem<ddc::Deriv<I>>(e)); });
     }
 
-    ddc::ChunkSpan const derivs_rhs_view
-            = derivs[ddc::DiscreteElement<DDimI>(derivs.domain().back())];
+    ddc::ChunkSpan const derivs_rhs_view = derivs[interpolation_domain.front()];
     if (s_bcr == ddc::BoundCond::HERMITE) {
         ddc::Chunk derivs_rhs_host_alloc(derivs_domain, ddc::HostAllocator<double>());
         ddc::ChunkSpan const derivs_rhs_host = derivs_rhs_host_alloc.span_view();

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -165,9 +165,6 @@ void BatchedSplineTest()
             DElem<ddc::Deriv<I>>(1),
             DVect<ddc::Deriv<I>>(s_degree_x / 2),
             DVect<ddc::Deriv<I>>(1));
-    auto const dom_derivs = ddc::replace_dim_of<
-            DDimI,
-            ddc::Deriv<I>>(ddc::detail::to_strided_ddom(dom_vals), derivs_domain);
 
     auto const whole_derivs_domain = ddc::detail::get_whole_derivs_domain<
             ddc::Deriv<I>>(interpolation_domain, dom_vals, s_degree_x / 2);

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -199,14 +199,21 @@ void ExtrapolationRuleSplineTest()
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Create empty ChunkSpans for the derivatives, as they are not used here
-    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDimI1, ddc::Deriv<I1>, DDimI2>> const
-            derivs1 {};
-    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDimI2, DDimI1, ddc::Deriv<I2>>> const
-            derivs2 {};
     ddc::ChunkSpan<
             double const,
-            ddc::StridedDiscreteDomain<DDimI1, DDimI2, ddc::Deriv<I1>, ddc::Deriv<I2>>> const
-            mixed_derivs1_2 {};
+            ddc::StridedDiscreteDomain<DDimI1, ddc::Deriv<I1>, DDimI2>,
+            Kokkos::layout_right,
+            MemorySpace> const derivs1 {};
+    ddc::ChunkSpan<
+            double const,
+            ddc::StridedDiscreteDomain<DDimI2, DDimI1, ddc::Deriv<I2>>,
+            Kokkos::layout_right,
+            MemorySpace> const derivs2 {};
+    ddc::ChunkSpan<
+            double const,
+            ddc::StridedDiscreteDomain<DDimI1, DDimI2, ddc::Deriv<I1>, ddc::Deriv<I2>>,
+            Kokkos::layout_right,
+            MemorySpace> const mixed_derivs1_2 {};
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
     ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -198,6 +198,16 @@ void ExtrapolationRuleSplineTest()
             = spline_builder.interpolation_domain();
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
+    // Create empty ChunkSpans for the derivatives, as they are not used here
+    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDimI1, ddc::Deriv<I1>, DDimI2>>
+            derivs1;
+    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDimI2, DDimI1, ddc::Deriv<I2>>>
+            derivs2;
+    ddc::ChunkSpan<
+            double const,
+            ddc::StridedDiscreteDomain<DDimI1, DDimI2, ddc::Deriv<I1>, ddc::Deriv<I2>>>
+            mixed_derivs1_2;
+
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
     ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
@@ -220,7 +230,12 @@ void ExtrapolationRuleSplineTest()
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
-    spline_builder(coef, vals.span_cview());
+    spline_builder(
+            coef,
+            vals.span_cview(),
+            derivs1.span_cview(),
+            derivs2.span_cview(),
+            mixed_derivs1_2.span_cview());
 
     // Instantiate a SplineEvaluator over interest dimension and batched along other dimensions
 #if defined(ER_NULL)

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -199,14 +199,14 @@ void ExtrapolationRuleSplineTest()
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Create empty ChunkSpans for the derivatives, as they are not used here
-    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDimI1, ddc::Deriv<I1>, DDimI2>>
-            derivs1;
-    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDimI2, DDimI1, ddc::Deriv<I2>>>
-            derivs2;
+    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDimI1, ddc::Deriv<I1>, DDimI2>> const
+            derivs1 {};
+    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDimI2, DDimI1, ddc::Deriv<I2>>> const
+            derivs2 {};
     ddc::ChunkSpan<
             double const,
-            ddc::StridedDiscreteDomain<DDimI1, DDimI2, ddc::Deriv<I1>, ddc::Deriv<I2>>>
-            mixed_derivs1_2;
+            ddc::StridedDiscreteDomain<DDimI1, DDimI2, ddc::Deriv<I1>, ddc::Deriv<I2>>> const
+            mixed_derivs1_2 {};
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
     ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());

--- a/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
@@ -184,25 +184,28 @@ std::tuple<double, double, double, double> ComputeEvaluationError(
             interpolation_domain(interpolation_domain1, interpolation_domain2);
 
     // Create the derivs domain
+    int const nbc_i1 = s_degree / 2;
+    int const nbc_i2 = s_degree / 2;
+
     ddc::DiscreteDomain<ddc::Deriv<I1>> const
-            derivs_ddom1(DElem<ddc::Deriv<I1>>(1), DVect<ddc::Deriv<I1>>(s_degree / 2));
+            derivs_ddom1(DElem<ddc::Deriv<I1>>(1), DVect<ddc::Deriv<I1>>(nbc_i1));
     ddc::DiscreteDomain<ddc::Deriv<I2>> const
-            derivs_ddom2(DElem<ddc::Deriv<I2>>(1), DVect<ddc::Deriv<I2>>(s_degree / 2));
+            derivs_ddom2(DElem<ddc::Deriv<I2>>(1), DVect<ddc::Deriv<I2>>(nbc_i2));
     ddc::DiscreteDomain<ddc::Deriv<I1>, ddc::Deriv<I2>> const
             derivs_ddom(derivs_ddom1, derivs_ddom2);
 
     ddc::StridedDiscreteDomain<ddc::Deriv<I1>, ddc::Deriv<I2>> const derivs_domain(
             DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(1, 1),
-            DVect<ddc::Deriv<I1>, ddc::Deriv<I2>>(s_degree / 2, s_degree / 2),
+            DVect<ddc::Deriv<I1>, ddc::Deriv<I2>>(nbc_i1, nbc_i2),
             DVect<ddc::Deriv<I1>, ddc::Deriv<I2>>(1, 1));
 
     auto const whole_derivs_domain1 = ddc::detail::get_whole_derivs_domain<
-            ddc::Deriv<I1>>(interpolation_domain1, dom_vals, s_degree);
+            ddc::Deriv<I1>>(interpolation_domain1, dom_vals, nbc_i1);
     auto const whole_derivs_domain2 = ddc::detail::get_whole_derivs_domain<
-            ddc::Deriv<I2>>(interpolation_domain2, dom_vals, s_degree);
+            ddc::Deriv<I2>>(interpolation_domain2, dom_vals, nbc_i2);
     auto const whole_derivs_domain = ddc::detail::get_whole_derivs_domain<
             ddc::Deriv<I1>,
-            ddc::Deriv<I2>>(interpolation_domain, dom_vals, s_degree);
+            ddc::Deriv<I2>>(interpolation_domain, dom_vals, nbc_i1, nbc_i2);
     auto const dom_derivs = ddc::remove_dims_of<DDimI1, DDimI2>(whole_derivs_domain);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions

--- a/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
@@ -5,9 +5,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <tuple>
-#if defined(BC_HERMITE)
-#    include <optional>
-#endif
 #if defined(BSPLINES_TYPE_UNIFORM)
 #    include <type_traits>
 #endif
@@ -176,28 +173,37 @@ std::tuple<double, double, double, double> ComputeEvaluationError(
     using I1 = typename DDimI1::continuous_dimension_type;
     using I2 = typename DDimI2::continuous_dimension_type;
 
-#if defined(BC_HERMITE)
-    ddc::DiscreteDomain<DDimI1> const interpolation_domain1(dom_vals);
-    ddc::DiscreteDomain<DDimI2> const interpolation_domain2(dom_vals);
-    // Create the derivs domain
-    ddc::DiscreteDomain<ddc::Deriv<I1>> const
-            derivs_domain1(DElem<ddc::Deriv<I1>>(1), DVect<ddc::Deriv<I1>>(s_degree / 2));
-    ddc::DiscreteDomain<ddc::Deriv<I2>> const
-            derivs_domain2(DElem<ddc::Deriv<I2>>(1), DVect<ddc::Deriv<I2>>(s_degree / 2));
-    ddc::DiscreteDomain<ddc::Deriv<I1>, ddc::Deriv<I2>> const
-            derivs_domain(derivs_domain1, derivs_domain2);
-
-    auto const dom_derivs_1d
-            = ddc::replace_dim_of<DDimI1, ddc::Deriv<I1>>(dom_vals, derivs_domain1);
-    auto const dom_derivs2 = ddc::replace_dim_of<DDimI2, ddc::Deriv<I2>>(dom_vals, derivs_domain2);
-    auto const dom_derivs
-            = ddc::replace_dim_of<DDimI2, ddc::Deriv<I2>>(dom_derivs_1d, derivs_domain2);
-#endif
-
-    // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
+    // Compute useful domains
     ddc::DiscreteDomain<DDimI1, DDimI2> const dom_interpolation
             = spline_builder.interpolation_domain();
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
+
+    ddc::DiscreteDomain<DDimI1> const interpolation_domain1(dom_vals);
+    ddc::DiscreteDomain<DDimI2> const interpolation_domain2(dom_vals);
+    ddc::DiscreteDomain<DDimI1, DDimI2> const
+            interpolation_domain(interpolation_domain1, interpolation_domain2);
+
+    // Create the derivs domain
+    ddc::DiscreteDomain<ddc::Deriv<I1>> const
+            derivs_ddom1(DElem<ddc::Deriv<I1>>(1), DVect<ddc::Deriv<I1>>(s_degree / 2));
+    ddc::DiscreteDomain<ddc::Deriv<I2>> const
+            derivs_ddom2(DElem<ddc::Deriv<I2>>(1), DVect<ddc::Deriv<I2>>(s_degree / 2));
+    ddc::DiscreteDomain<ddc::Deriv<I1>, ddc::Deriv<I2>> const
+            derivs_ddom(derivs_ddom1, derivs_ddom2);
+
+    ddc::StridedDiscreteDomain<ddc::Deriv<I1>, ddc::Deriv<I2>> const derivs_domain(
+            DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(1, 1),
+            DVect<ddc::Deriv<I1>, ddc::Deriv<I2>>(s_degree / 2, s_degree / 2),
+            DVect<ddc::Deriv<I1>, ddc::Deriv<I2>>(1, 1));
+
+    auto const whole_derivs_domain1 = ddc::detail::get_whole_derivs_domain<
+            ddc::Deriv<I1>>(interpolation_domain1, dom_vals, s_degree);
+    auto const whole_derivs_domain2 = ddc::detail::get_whole_derivs_domain<
+            ddc::Deriv<I2>>(interpolation_domain2, dom_vals, s_degree);
+    auto const whole_derivs_domain = ddc::detail::get_whole_derivs_domain<
+            ddc::Deriv<I1>,
+            ddc::Deriv<I2>>(interpolation_domain, dom_vals, s_degree);
+    auto const dom_derivs = ddc::remove_dims_of<DDimI1, DDimI2>(whole_derivs_domain);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
     ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
@@ -215,141 +221,156 @@ std::tuple<double, double, double, double> ComputeEvaluationError(
                 vals(e) = vals_1d(DElem<DDimI1, DDimI2>(e));
             });
 
-#if defined(BC_HERMITE)
     // Allocate and fill a chunk containing derivs to be passed as input to spline_builder.
     int const shift = s_degree % 2; // shift = 0 for even order, 1 for odd order
-    ddc::Chunk derivs_1d_lhs_alloc(dom_derivs_1d, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_1d_lhs = derivs_1d_lhs_alloc.span_view();
+
+    ddc::Chunk derivs1_alloc(whole_derivs_domain1, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::ChunkSpan const derivs1 = derivs1_alloc.span_view();
+
     if (s_bcl == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs_1d_lhs1_host_alloc(
-                ddc::DiscreteDomain<ddc::Deriv<I1>, DDimI2>(derivs_domain1, interpolation_domain2),
+        ddc::ChunkSpan const derivs1_lhs_view
+                = ddc::detail::derivs(derivs1, ddc::detail::dmin<DDimI1>);
+
+        ddc::Chunk derivs1_lhs_host_alloc(
+                ddc::DiscreteDomain<ddc::Deriv<I1>, DDimI2>(derivs_ddom1, interpolation_domain2),
                 ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_1d_lhs1_host = derivs_1d_lhs1_host_alloc.span_view();
+        ddc::ChunkSpan const derivs1_lhs_host = derivs1_lhs_host_alloc.span_view();
         ddc::for_each(
-                derivs_1d_lhs1_host.domain(),
+                derivs1_lhs_host.domain(),
                 KOKKOS_LAMBDA(ddc::DiscreteElement<ddc::Deriv<I1>, DDimI2> const e) {
                     auto deriv_idx = ddc::DiscreteElement<ddc::Deriv<I1>>(e).uid();
                     auto x2 = ddc::coordinate(ddc::DiscreteElement<DDimI2>(e));
-                    derivs_1d_lhs1_host(e)
-                            = evaluator.deriv(x0<I1>(), x2, deriv_idx + shift - 1, 0);
+                    derivs1_lhs_host(e) = evaluator.deriv(x0<I1>(), x2, deriv_idx + shift - 1, 0);
                 });
-        auto derivs_1d_lhs1_alloc
-                = ddc::create_mirror_view_and_copy(exec_space, derivs_1d_lhs1_host);
-        ddc::ChunkSpan const derivs_1d_lhs1 = derivs_1d_lhs1_alloc.span_view();
+        auto derivs1_lhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs1_lhs_host);
+        ddc::ChunkSpan const derivs1_lhs = derivs1_lhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
-                derivs_1d_lhs.domain(),
+                derivs1_lhs_view.domain(),
                 KOKKOS_LAMBDA(
-                        typename decltype(derivs_1d_lhs.domain())::discrete_element_type const e) {
-                    derivs_1d_lhs(e) = derivs_1d_lhs1(DElem<ddc::Deriv<I1>, DDimI2>(e));
+                        typename decltype(derivs1_lhs_view
+                                                  .domain())::discrete_element_type const e) {
+                    derivs1_lhs_view(e) = derivs1_lhs(DElem<ddc::Deriv<I1>, DDimI2>(e));
                 });
     }
 
-    ddc::Chunk derivs_1d_rhs_alloc(dom_derivs_1d, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_1d_rhs = derivs_1d_rhs_alloc.span_view();
     if (s_bcl == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs_1d_rhs1_host_alloc(
-                ddc::DiscreteDomain<ddc::Deriv<I1>, DDimI2>(derivs_domain1, interpolation_domain2),
+        ddc::ChunkSpan const derivs1_rhs_view
+                = ddc::detail::derivs(derivs1, ddc::detail::dmax<DDimI1>);
+
+        ddc::Chunk derivs1_rhs_host_alloc(
+                ddc::DiscreteDomain<ddc::Deriv<I1>, DDimI2>(derivs_ddom1, interpolation_domain2),
                 ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_1d_rhs1_host = derivs_1d_rhs1_host_alloc.span_view();
+        ddc::ChunkSpan const derivs1_rhs_host = derivs1_rhs_host_alloc.span_view();
         ddc::for_each(
-                derivs_1d_rhs1_host.domain(),
+                derivs1_rhs_host.domain(),
                 KOKKOS_LAMBDA(ddc::DiscreteElement<ddc::Deriv<I1>, DDimI2> const e) {
                     auto deriv_idx = ddc::DiscreteElement<ddc::Deriv<I1>>(e).uid();
                     auto x2 = ddc::coordinate(ddc::DiscreteElement<DDimI2>(e));
-                    derivs_1d_rhs1_host(e)
-                            = evaluator.deriv(xN<I1>(), x2, deriv_idx + shift - 1, 0);
+                    derivs1_rhs_host(e) = evaluator.deriv(xN<I1>(), x2, deriv_idx + shift - 1, 0);
                 });
-        auto derivs_1d_rhs1_alloc
-                = ddc::create_mirror_view_and_copy(exec_space, derivs_1d_rhs1_host);
-        ddc::ChunkSpan const derivs_1d_rhs1 = derivs_1d_rhs1_alloc.span_view();
+        auto derivs1_rhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs1_rhs_host);
+        ddc::ChunkSpan const derivs1_rhs = derivs1_rhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
-                derivs_1d_rhs.domain(),
+                derivs1_rhs_view.domain(),
                 KOKKOS_LAMBDA(
-                        typename decltype(derivs_1d_rhs.domain())::discrete_element_type const e) {
-                    derivs_1d_rhs(e) = derivs_1d_rhs1(DElem<ddc::Deriv<I1>, DDimI2>(e));
+                        typename decltype(derivs1_rhs_view
+                                                  .domain())::discrete_element_type const e) {
+                    derivs1_rhs_view(e) = derivs1_rhs(DElem<ddc::Deriv<I1>, DDimI2>(e));
                 });
     }
 
-    ddc::Chunk derivs2_lhs_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs2_lhs = derivs2_lhs_alloc.span_view();
+    ddc::Chunk derivs2_alloc(whole_derivs_domain2, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::ChunkSpan const derivs2 = derivs2_alloc.span_view();
+
     if (s_bcl == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs2_lhs1_host_alloc(
-                ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>>(interpolation_domain1, derivs_domain2),
+        ddc::ChunkSpan const derivs2_lhs_view
+                = ddc::detail::derivs(derivs2, ddc::detail::dmin<DDimI2>);
+
+        ddc::Chunk derivs2_lhs_host_alloc(
+                ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>>(interpolation_domain1, derivs_ddom2),
                 ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs2_lhs1_host = derivs2_lhs1_host_alloc.span_view();
+        ddc::ChunkSpan const derivs2_lhs_host = derivs2_lhs_host_alloc.span_view();
         ddc::for_each(
-                derivs2_lhs1_host.domain(),
+                derivs2_lhs_host.domain(),
                 KOKKOS_LAMBDA(ddc::DiscreteElement<DDimI1, ddc::Deriv<I2>> const e) {
                     auto x1 = ddc::coordinate(ddc::DiscreteElement<DDimI1>(e));
                     auto deriv_idx = ddc::DiscreteElement<ddc::Deriv<I2>>(e).uid();
-                    derivs2_lhs1_host(e) = evaluator.deriv(x1, x0<I2>(), 0, deriv_idx + shift - 1);
+                    derivs2_lhs_host(e) = evaluator.deriv(x1, x0<I2>(), 0, deriv_idx + shift - 1);
                 });
 
-        auto derivs2_lhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs2_lhs1_host);
-        ddc::ChunkSpan const derivs2_lhs1 = derivs2_lhs1_alloc.span_view();
+        auto derivs2_lhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs2_lhs_host);
+        ddc::ChunkSpan const derivs2_lhs = derivs2_lhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
-                derivs2_lhs.domain(),
+                derivs2_lhs_view.domain(),
                 KOKKOS_LAMBDA(
-                        typename decltype(derivs2_lhs.domain())::discrete_element_type const e) {
-                    derivs2_lhs(e) = derivs2_lhs1(DElem<DDimI1, ddc::Deriv<I2>>(e));
+                        typename decltype(derivs2_lhs_view
+                                                  .domain())::discrete_element_type const e) {
+                    derivs2_lhs_view(e) = derivs2_lhs(DElem<DDimI1, ddc::Deriv<I2>>(e));
                 });
     }
 
-    ddc::Chunk derivs2_rhs_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs2_rhs = derivs2_rhs_alloc.span_view();
     if (s_bcl == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs2_rhs1_host_alloc(
-                ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>>(interpolation_domain1, derivs_domain2),
+        ddc::ChunkSpan const derivs2_rhs_view
+                = ddc::detail::derivs(derivs2, ddc::detail::dmax<DDimI2>);
+
+        ddc::Chunk derivs2_rhs_host_alloc(
+                ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>>(interpolation_domain1, derivs_ddom2),
                 ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs2_rhs1_host = derivs2_rhs1_host_alloc.span_view();
+        ddc::ChunkSpan const derivs2_rhs_host = derivs2_rhs_host_alloc.span_view();
         ddc::for_each(
-                derivs2_rhs1_host.domain(),
+                derivs2_rhs_host.domain(),
                 KOKKOS_LAMBDA(ddc::DiscreteElement<DDimI1, ddc::Deriv<I2>> const e) {
                     auto x1 = ddc::coordinate(ddc::DiscreteElement<DDimI1>(e));
                     auto deriv_idx = ddc::DiscreteElement<ddc::Deriv<I2>>(e).uid();
-                    derivs2_rhs1_host(e) = evaluator.deriv(x1, xN<I2>(), 0, deriv_idx + shift - 1);
+                    derivs2_rhs_host(e) = evaluator.deriv(x1, xN<I2>(), 0, deriv_idx + shift - 1);
                 });
 
-        auto derivs2_rhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs2_rhs1_host);
-        ddc::ChunkSpan const derivs2_rhs1 = derivs2_rhs1_alloc.span_view();
+        auto derivs2_rhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs2_rhs_host);
+        ddc::ChunkSpan const derivs2_rhs = derivs2_rhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
-                derivs2_rhs.domain(),
+                derivs2_rhs_view.domain(),
                 KOKKOS_LAMBDA(
-                        typename decltype(derivs2_rhs.domain())::discrete_element_type const e) {
-                    derivs2_rhs(e) = derivs2_rhs1(DElem<DDimI1, ddc::Deriv<I2>>(e));
+                        typename decltype(derivs2_rhs_view
+                                                  .domain())::discrete_element_type const e) {
+                    derivs2_rhs_view(e) = derivs2_rhs(DElem<DDimI1, ddc::Deriv<I2>>(e));
                 });
     }
 
-    ddc::Chunk derivs_mixed_lhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs_lhs = derivs_mixed_lhs_lhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs_lhs = derivs_mixed_rhs_lhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_lhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_lhs_rhs = derivs_mixed_lhs_rhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_mixed_rhs_rhs = derivs_mixed_rhs_rhs_alloc.span_view();
+    ddc::Chunk derivs_mixed_1_2_alloc(
+            whole_derivs_domain,
+            ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::ChunkSpan const derivs_mixed_1_2 = derivs_mixed_1_2_alloc.span_view();
 
     if (s_bcl == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_mixed_lhs_lhs1_host
-                = derivs_mixed_lhs_lhs1_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_mixed_rhs_lhs1_host
-                = derivs_mixed_rhs_lhs1_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_mixed_lhs_rhs1_host
-                = derivs_mixed_lhs_rhs1_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_mixed_rhs_rhs1_host
-                = derivs_mixed_rhs_rhs1_host_alloc.span_view();
+        ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_view = ddc::detail::
+                derivs(derivs_mixed_1_2, ddc::detail::dmin<DDimI1>, ddc::detail::dmin<DDimI2>);
+        ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_view = ddc::detail::
+                derivs(derivs_mixed_1_2, ddc::detail::dmax<DDimI1>, ddc::detail::dmin<DDimI2>);
+        ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_view = ddc::detail::
+                derivs(derivs_mixed_1_2, ddc::detail::dmin<DDimI1>, ddc::detail::dmax<DDimI2>);
+        ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_view = ddc::detail::
+                derivs(derivs_mixed_1_2, ddc::detail::dmax<DDimI1>, ddc::detail::dmax<DDimI2>);
+
+        ddc::Chunk derivs_mixed_lhs1_lhs2_host_alloc(derivs_ddom, ddc::HostAllocator<double>());
+        ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_host
+                = derivs_mixed_lhs1_lhs2_host_alloc.span_view();
+        ddc::Chunk derivs_mixed_rhs1_lhs2_host_alloc(derivs_ddom, ddc::HostAllocator<double>());
+        ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_host
+                = derivs_mixed_rhs1_lhs2_host_alloc.span_view();
+        ddc::Chunk derivs_mixed_lhs1_rhs2_host_alloc(derivs_ddom, ddc::HostAllocator<double>());
+        ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_host
+                = derivs_mixed_lhs1_rhs2_host_alloc.span_view();
+        ddc::Chunk derivs_mixed_rhs1_rhs2_host_alloc(derivs_ddom, ddc::HostAllocator<double>());
+        ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_host
+                = derivs_mixed_rhs1_rhs2_host_alloc.span_view();
 
         for (std::size_t ii = 1;
              ii < static_cast<std::size_t>(derivs_domain.template extent<ddc::Deriv<I1>>()) + 1;
@@ -357,69 +378,59 @@ std::tuple<double, double, double, double> ComputeEvaluationError(
             for (std::size_t jj = 1;
                  jj < static_cast<std::size_t>(derivs_domain.template extent<ddc::Deriv<I2>>()) + 1;
                  ++jj) {
-                derivs_mixed_lhs_lhs1_host(
+                derivs_mixed_lhs1_lhs2_host(
                         typename decltype(derivs_domain)::discrete_element_type(ii, jj))
                         = evaluator.deriv(x0<I1>(), x0<I2>(), ii + shift - 1, jj + shift - 1);
-                derivs_mixed_rhs_lhs1_host(
+                derivs_mixed_rhs1_lhs2_host(
                         typename decltype(derivs_domain)::discrete_element_type(ii, jj))
                         = evaluator.deriv(xN<I1>(), x0<I2>(), ii + shift - 1, jj + shift - 1);
-                derivs_mixed_lhs_rhs1_host(
+                derivs_mixed_lhs1_rhs2_host(
                         typename decltype(derivs_domain)::discrete_element_type(ii, jj))
                         = evaluator.deriv(x0<I1>(), xN<I2>(), ii + shift - 1, jj + shift - 1);
-                derivs_mixed_rhs_rhs1_host(
+                derivs_mixed_rhs1_rhs2_host(
                         typename decltype(derivs_domain)::discrete_element_type(ii, jj))
                         = evaluator.deriv(xN<I1>(), xN<I2>(), ii + shift - 1, jj + shift - 1);
             }
         }
-        auto derivs_mixed_lhs_lhs1_alloc
-                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_lhs_lhs1_host);
-        ddc::ChunkSpan const derivs_mixed_lhs_lhs1 = derivs_mixed_lhs_lhs1_alloc.span_view();
-        auto derivs_mixed_rhs_lhs1_alloc
-                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_rhs_lhs1_host);
-        ddc::ChunkSpan const derivs_mixed_rhs_lhs1 = derivs_mixed_rhs_lhs1_alloc.span_view();
-        auto derivs_mixed_lhs_rhs1_alloc
-                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_lhs_rhs1_host);
-        ddc::ChunkSpan const derivs_mixed_lhs_rhs1 = derivs_mixed_lhs_rhs1_alloc.span_view();
-        auto derivs_mixed_rhs_rhs1_alloc
-                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_rhs_rhs1_host);
-        ddc::ChunkSpan const derivs_mixed_rhs_rhs1 = derivs_mixed_rhs_rhs1_alloc.span_view();
+        auto derivs_mixed_lhs1_lhs2_alloc
+                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_lhs1_lhs2_host);
+        ddc::ChunkSpan const derivs_mixed_lhs1_lhs2 = derivs_mixed_lhs1_lhs2_alloc.span_view();
+        auto derivs_mixed_rhs1_lhs2_alloc
+                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_rhs1_lhs2_host);
+        ddc::ChunkSpan const derivs_mixed_rhs1_lhs2 = derivs_mixed_rhs1_lhs2_alloc.span_view();
+        auto derivs_mixed_lhs1_rhs2_alloc
+                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_lhs1_rhs2_host);
+        ddc::ChunkSpan const derivs_mixed_lhs1_rhs2 = derivs_mixed_lhs1_rhs2_alloc.span_view();
+        auto derivs_mixed_rhs1_rhs2_alloc
+                = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_rhs1_rhs2_host);
+        ddc::ChunkSpan const derivs_mixed_rhs1_rhs2 = derivs_mixed_rhs1_rhs2_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
                 dom_derivs,
                 KOKKOS_LAMBDA(typename decltype(dom_derivs)::discrete_element_type const e) {
-                    derivs_mixed_lhs_lhs(e)
-                            = derivs_mixed_lhs_lhs1(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
-                    derivs_mixed_rhs_lhs(e)
-                            = derivs_mixed_rhs_lhs1(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
-                    derivs_mixed_lhs_rhs(e)
-                            = derivs_mixed_lhs_rhs1(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
-                    derivs_mixed_rhs_rhs(e)
-                            = derivs_mixed_rhs_rhs1(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
+                    derivs_mixed_lhs1_lhs2_view(e)
+                            = derivs_mixed_lhs1_lhs2(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
+                    derivs_mixed_rhs1_lhs2_view(e)
+                            = derivs_mixed_rhs1_lhs2(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
+                    derivs_mixed_lhs1_rhs2_view(e)
+                            = derivs_mixed_lhs1_rhs2(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
+                    derivs_mixed_rhs1_rhs2_view(e)
+                            = derivs_mixed_rhs1_rhs2(DElem<ddc::Deriv<I1>, ddc::Deriv<I2>>(e));
                 });
     }
-#endif
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
     ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
-#if defined(BC_HERMITE)
     spline_builder(
             coef,
             vals.span_cview(),
-            std::optional(derivs_1d_lhs.span_cview()),
-            std::optional(derivs_1d_rhs.span_cview()),
-            std::optional(derivs2_lhs.span_cview()),
-            std::optional(derivs2_rhs.span_cview()),
-            std::optional(derivs_mixed_lhs_lhs.span_cview()),
-            std::optional(derivs_mixed_rhs_lhs.span_cview()),
-            std::optional(derivs_mixed_lhs_rhs.span_cview()),
-            std::optional(derivs_mixed_rhs_rhs.span_cview()));
-#else
-    spline_builder(coef, vals.span_cview());
-#endif
+            derivs1.span_cview(),
+            derivs2.span_cview(),
+            derivs_mixed_1_2.span_cview());
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<I1, I2>, MemorySpace>());

--- a/tests/splines/multiple_batch_domain_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_spline_builder.cpp
@@ -167,9 +167,7 @@ std::tuple<double, double, double> ComputeEvaluationError(
             DElem<ddc::Deriv<I>>(1),
             DVect<ddc::Deriv<I>>(s_degree_x / 2),
             DVect<ddc::Deriv<I>>(1));
-    auto const dom_derivs = ddc::replace_dim_of<
-            DDimI,
-            ddc::Deriv<I>>(ddc::detail::to_strided_ddom(dom_vals), derivs_domain);
+
     auto const whole_derivs_domain = ddc::detail::get_whole_derivs_domain<
             ddc::Deriv<I>>(dom_interpolation, dom_vals, s_degree_x / 2);
 

--- a/tests/splines/multiple_batch_domain_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_spline_builder.cpp
@@ -190,8 +190,9 @@ std::tuple<double, double, double> ComputeEvaluationError(
     ddc::Chunk derivs_alloc(whole_derivs_domain, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan const derivs = derivs_alloc.span_view();
 
-    ddc::ChunkSpan const derivs_lhs_view = derivs[dom_interpolation.front()];
     if (s_bcl == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs_lhs_view = derivs[dom_interpolation.front()];
+
         ddc::Chunk derivs_lhs_host_alloc(derivs_domain, ddc::HostAllocator<double>());
         ddc::ChunkSpan const derivs_lhs_host = derivs_lhs_host_alloc.span_view();
         for (int ii = 1; ii < derivs_lhs_host.domain().template extent<ddc::Deriv<I>>() + 1; ++ii) {
@@ -208,8 +209,9 @@ std::tuple<double, double, double> ComputeEvaluationError(
                                 e) { derivs_lhs_view(e) = derivs_lhs(DElem<ddc::Deriv<I>>(e)); });
     }
 
-    ddc::ChunkSpan const derivs_rhs_view = derivs[dom_interpolation.front()];
     if (s_bcr == ddc::BoundCond::HERMITE) {
+        ddc::ChunkSpan const derivs_rhs_view = derivs[dom_interpolation.back()];
+
         ddc::Chunk derivs_rhs_host_alloc(derivs_domain, ddc::HostAllocator<double>());
         ddc::ChunkSpan const derivs_rhs_host = derivs_rhs_host_alloc.span_view();
         for (int ii = 1; ii < derivs_rhs_host.domain().template extent<ddc::Deriv<I>>() + 1; ++ii) {

--- a/tests/splines/multiple_batch_domain_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_spline_builder.cpp
@@ -171,7 +171,7 @@ std::tuple<double, double, double> ComputeEvaluationError(
             DDimI,
             ddc::Deriv<I>>(ddc::detail::to_strided_ddom(dom_vals), derivs_domain);
     auto const whole_derivs_domain = ddc::detail::get_whole_derivs_domain<
-            ddc::Deriv<I>>(dom_interpolation, dom_vals, s_degree_x);
+            ddc::Deriv<I>>(dom_interpolation, dom_vals, s_degree_x / 2);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
     ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());

--- a/tests/splines/multiple_batch_domain_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_spline_builder.cpp
@@ -157,12 +157,16 @@ std::tuple<double, double, double> ComputeEvaluationError(
 {
     using I = typename DDimI::continuous_dimension_type;
 
-#if defined(BC_HERMITE)
     // Create the derivs domains
-    ddc::DiscreteDomain<ddc::Deriv<I>> const
-            derivs_domain(DElem<ddc::Deriv<I>>(1), DVect<ddc::Deriv<I>>(s_degree_x / 2));
-    auto const dom_derivs = ddc::replace_dim_of<DDimI, ddc::Deriv<I>>(dom_vals, derivs_domain);
-#endif
+    ddc::StridedDiscreteDomain<ddc::Deriv<I>> const derivs_domain(
+            DElem<ddc::Deriv<I>>(1),
+            DVect<ddc::Deriv<I>>(s_degree_x / 2),
+            DVect<ddc::Deriv<I>>(1));
+    ddc::StridedDiscreteDomain<ddc::Deriv<I>, DDims...> const
+            whole_derivs_domain(derivs_domain, ddc::detail::to_strided_ddom(dom_vals));
+    auto const dom_derivs = ddc::replace_dim_of<
+            DDimI,
+            ddc::Deriv<I>>(ddc::detail::to_strided_ddom(dom_vals), derivs_domain);
 
     // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
     ddc::DiscreteDomain<DDimI> const dom_interpolation = spline_builder.interpolation_domain();
@@ -183,69 +187,56 @@ std::tuple<double, double, double> ComputeEvaluationError(
             vals.domain(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) { vals(e) = vals_1d(DElem<DDimI>(e)); });
 
-#if defined(BC_HERMITE)
     // Allocate and fill a chunk containing derivs to be passed as input to spline_builder.
     int const shift = s_degree_x % 2; // shift = 0 for even order, 1 for odd order
-    ddc::Chunk derivs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_lhs = derivs_lhs_alloc.span_view();
+    ddc::Chunk derivs_alloc(whole_derivs_domain, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::ChunkSpan const derivs = derivs_alloc.span_view();
+
+    ddc::ChunkSpan const derivs_lhs_view
+            = derivs[ddc::DiscreteElement<DDimI>(derivs.domain().front())];
     if (s_bcl == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_lhs1_host = derivs_lhs1_host_alloc.span_view();
-        for (int ii = 1; ii < derivs_lhs1_host.domain().template extent<ddc::Deriv<I>>() + 1;
-             ++ii) {
-            derivs_lhs1_host(
-                    typename decltype(derivs_lhs1_host.domain())::discrete_element_type(ii))
+        ddc::Chunk derivs_lhs_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::ChunkSpan const derivs_lhs_host = derivs_lhs_host_alloc.span_view();
+        for (int ii = 1; ii < derivs_lhs_host.domain().template extent<ddc::Deriv<I>>() + 1; ++ii) {
+            derivs_lhs_host(typename decltype(derivs_lhs_host.domain())::discrete_element_type(ii))
                     = evaluator.deriv(x0<I>(), ii + shift - 1);
         }
-        auto derivs_lhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs_lhs1_host);
-        ddc::ChunkSpan const derivs_lhs1 = derivs_lhs1_alloc.span_view();
+        auto derivs_lhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs_lhs_host);
+        ddc::ChunkSpan const derivs_lhs = derivs_lhs_alloc.span_view();
         ddc::parallel_for_each(
                 exec_space,
-                derivs_lhs.domain(),
+                derivs_lhs_view.domain(),
                 KOKKOS_LAMBDA(
-                        typename decltype(derivs_lhs.domain())::discrete_element_type const e) {
-                    derivs_lhs(e) = derivs_lhs1(DElem<ddc::Deriv<I>>(e));
-                });
+                        typename decltype(derivs_lhs_view.domain())::discrete_element_type const
+                                e) { derivs_lhs_view(e) = derivs_lhs(DElem<ddc::Deriv<I>>(e)); });
     }
 
-    ddc::Chunk derivs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
-    ddc::ChunkSpan const derivs_rhs = derivs_rhs_alloc.span_view();
+    ddc::ChunkSpan const derivs_rhs_view
+            = derivs[ddc::DiscreteElement<DDimI>(derivs.domain().back())];
     if (s_bcr == ddc::BoundCond::HERMITE) {
-        ddc::Chunk derivs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
-        ddc::ChunkSpan const derivs_rhs1_host = derivs_rhs1_host_alloc.span_view();
-        for (int ii = 1; ii < derivs_rhs1_host.domain().template extent<ddc::Deriv<I>>() + 1;
-             ++ii) {
-            derivs_rhs1_host(
-                    typename decltype(derivs_rhs1_host.domain())::discrete_element_type(ii))
+        ddc::Chunk derivs_rhs_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::ChunkSpan const derivs_rhs_host = derivs_rhs_host_alloc.span_view();
+        for (int ii = 1; ii < derivs_rhs_host.domain().template extent<ddc::Deriv<I>>() + 1; ++ii) {
+            derivs_rhs_host(typename decltype(derivs_rhs_host.domain())::discrete_element_type(ii))
                     = evaluator.deriv(xN<I>(), ii + shift - 1);
         }
-        auto derivs_rhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs_rhs1_host);
-        ddc::ChunkSpan const derivs_rhs1 = derivs_rhs1_alloc.span_view();
+        auto derivs_rhs_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs_rhs_host);
+        ddc::ChunkSpan const derivs_rhs = derivs_rhs_alloc.span_view();
 
         ddc::parallel_for_each(
                 exec_space,
-                derivs_rhs.domain(),
+                derivs_rhs_view.domain(),
                 KOKKOS_LAMBDA(
-                        typename decltype(derivs_rhs.domain())::discrete_element_type const e) {
-                    derivs_rhs(e) = derivs_rhs1(DElem<ddc::Deriv<I>>(e));
-                });
+                        typename decltype(derivs_rhs_view.domain())::discrete_element_type const
+                                e) { derivs_rhs_view(e) = derivs_rhs(DElem<ddc::Deriv<I>>(e)); });
     }
-#endif
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
     ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
-#if defined(BC_HERMITE)
-    spline_builder(
-            coef,
-            vals.span_cview(),
-            std::optional(derivs_lhs.span_cview()),
-            std::optional(derivs_rhs.span_cview()));
-#else
-    spline_builder(coef, vals.span_cview());
-#endif
+    spline_builder(coef, vals.span_cview(), derivs.span_cview());
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<I>, MemorySpace>());

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -112,7 +112,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
     ddc::DiscreteDomain<DDimX> const interpolation_domain(GrevillePoints::get_domain<DDimX>());
 
     auto const whole_derivs_domain = ddc::detail::get_whole_derivs_domain<
-            ddc::Deriv<DimX>>(interpolation_domain, s_degree_x);
+            ddc::Deriv<DimX>>(interpolation_domain, s_degree_x / 2);
 
     // 4. Create a SplineBuilder over BSplines using some boundary conditions
     ddc::SplineBuilder<

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -113,12 +113,6 @@ void TestNonPeriodicSplineBuilderTestIdentity()
 
     auto const whole_derivs_domain = ddc::detail::get_whole_derivs_domain<
             ddc::Deriv<DimX>>(interpolation_domain, s_degree_x);
-    // ddc::StridedDiscreteDomain<DDimX, ddc::Deriv<DimX>> const whole_derivs_domain(
-    //         ddc::DiscreteElement<DDimX, ddc::Deriv<DimX>>(0, 1),
-    //         ddc::DiscreteVector<DDimX, ddc::Deriv<DimX>>(2, s_degree_x / 2),
-    //         ddc::DiscreteVector<
-    //                 DDimX,
-    //                 ddc::Deriv<DimX>>(interpolation_domain.extent<DDimX>().value() - 2, 1));
 
     // 4. Create a SplineBuilder over BSplines using some boundary conditions
     ddc::SplineBuilder<

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -105,10 +105,13 @@ void TestPeriodicSplineBuilderTestIdentity()
             yvals.domain(),
             KOKKOS_LAMBDA(DElemX const ix) { yvals(ix) = evaluator(ddc::coordinate(ix)); });
 
-    // 6. Finally build the spline by filling `coef`
-    spline_builder(coef.span_view(), yvals.span_cview());
+    // 6. Create a empty chunk for the derivatives, as they are not used with periodic boundary conditions
+    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<ddc::Deriv<DimX>, DDimX>> derivs;
 
-    // 7. Create a SplineEvaluator to evaluate the spline at any point in the domain of the BSplines
+    // 7. Finally build the spline by filling `coef`
+    spline_builder(coef.span_view(), yvals.span_cview(), derivs);
+
+    // 8. Create a SplineEvaluator to evaluate the spline at any point in the domain of the BSplines
     ddc::PeriodicExtrapolationRule<DimX> const periodic_extrapolation;
     ddc::SplineEvaluator<
             execution_space,

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -106,7 +106,8 @@ void TestPeriodicSplineBuilderTestIdentity()
             KOKKOS_LAMBDA(DElemX const ix) { yvals(ix) = evaluator(ddc::coordinate(ix)); });
 
     // 6. Create a empty chunk for the derivatives, as they are not used with periodic boundary conditions
-    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDimX, ddc::Deriv<DimX>>> derivs;
+    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDimX, ddc::Deriv<DimX>>> const
+            derivs {};
 
     // 7. Finally build the spline by filling `coef`
     spline_builder(coef.span_view(), yvals.span_cview(), derivs);

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -106,8 +106,11 @@ void TestPeriodicSplineBuilderTestIdentity()
             KOKKOS_LAMBDA(DElemX const ix) { yvals(ix) = evaluator(ddc::coordinate(ix)); });
 
     // 6. Create a empty chunk for the derivatives, as they are not used with periodic boundary conditions
-    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDimX, ddc::Deriv<DimX>>> const
-            derivs {};
+    ddc::ChunkSpan<
+            double const,
+            ddc::StridedDiscreteDomain<DDimX, ddc::Deriv<DimX>>,
+            Kokkos::layout_right,
+            memory_space> const derivs {};
 
     // 7. Finally build the spline by filling `coef`
     spline_builder(coef.span_view(), yvals.span_cview(), derivs);

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -106,7 +106,7 @@ void TestPeriodicSplineBuilderTestIdentity()
             KOKKOS_LAMBDA(DElemX const ix) { yvals(ix) = evaluator(ddc::coordinate(ix)); });
 
     // 6. Create a empty chunk for the derivatives, as they are not used with periodic boundary conditions
-    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<ddc::Deriv<DimX>, DDimX>> derivs;
+    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDimX, ddc::Deriv<DimX>>> derivs;
 
     // 7. Finally build the spline by filling `coef`
     spline_builder(coef.span_view(), yvals.span_cview(), derivs);

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -148,8 +148,11 @@ void PeriodicitySplineBuilderTest()
     ddc::Chunk coef_alloc(dom_bsplines, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
+    // Instantiate empty chunk of derivatives
+    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<ddc::Deriv<X>, DDim<X>>> derivs;
+
     // Finally compute the spline by filling `coef`
-    spline_builder(coef, vals.span_cview());
+    spline_builder(coef, vals.span_cview(), derivs.span_cview());
 
     // Instantiate a SplineEvaluator over interest dimension and batched along other dimensions
     ddc::PeriodicExtrapolationRule<X> const extrapolation_rule;

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -149,7 +149,7 @@ void PeriodicitySplineBuilderTest()
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Instantiate empty chunk of derivatives
-    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<ddc::Deriv<X>, DDim<X>>> derivs;
+    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDim<X>, ddc::Deriv<X>>> derivs;
 
     // Finally compute the spline by filling `coef`
     spline_builder(coef, vals.span_cview(), derivs.span_cview());

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -149,7 +149,8 @@ void PeriodicitySplineBuilderTest()
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Instantiate empty chunk of derivatives
-    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDim<X>, ddc::Deriv<X>>> derivs;
+    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDim<X>, ddc::Deriv<X>>> const
+            derivs {};
 
     // Finally compute the spline by filling `coef`
     spline_builder(coef, vals.span_cview(), derivs.span_cview());

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -149,8 +149,11 @@ void PeriodicitySplineBuilderTest()
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Instantiate empty chunk of derivatives
-    ddc::ChunkSpan<double const, ddc::StridedDiscreteDomain<DDim<X>, ddc::Deriv<X>>> const
-            derivs {};
+    ddc::ChunkSpan<
+            double const,
+            ddc::StridedDiscreteDomain<DDim<X>, ddc::Deriv<X>>,
+            Kokkos::layout_right,
+            MemorySpace> const derivs {};
 
     // Finally compute the spline by filling `coef`
     spline_builder(coef, vals.span_cview(), derivs.span_cview());


### PR DESCRIPTION
This PR modifies the SplineBuilder interface to pass `StridedDiscreteDomain`s for the derivatives, which allows to pack some of the arguments and reduce the rate at which the number of arguments grows with the number of dimensions.

This is based on #929 