### PR TITLE
Update clang-format to version 21

### DIFF
--- a/.github/workflows/tests-ubuntu.yaml
+++ b/.github/workflows/tests-ubuntu.yaml
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
-      - uses: jidicula/clang-format-action@4726374d1aa3c6aecf132e5197e498979588ebc8  # v4.15.0
+      - uses: jidicula/clang-format-action@6cd220de46c89139a0365edae93eee8eb30ca8fe  # v4.16.0
         with:
-          clang-format-version: '20'
+          clang-format-version: '21'
       - name: Prefer 'if defined'/'if !defined' over 'ifdef'/'ifndef'
         run: if grep -RE "(ifdef|ifndef)" $(git ls-files '*.[ch]pp' ':!*/kokkos-kernels-ext/*'); then exit 1; fi
       - name: Do not include <iostream> in the headers of the library


### PR DESCRIPTION
Only the lint job is meaningful as there is no actual change in formatting of C++ files.