### PR TITLE
Enforce that the dimensions passed to discrete element, vector and domain are unique

### DIFF
--- a/include/ddc/detail/type_seq.hpp
+++ b/include/ddc/detail/type_seq.hpp
@@ -189,6 +189,9 @@ constexpr bool in_tags_v = false;
 template <class TypeSeq, class OTypeSeq>
 constexpr bool type_seq_contains_v = false;
 
+template <class TypeSeq>
+constexpr bool type_seq_is_unique_v = false;
+
 template <class TypeSeq, class B>
 constexpr bool type_seq_same_v = type_seq_contains_v<TypeSeq, B> && type_seq_contains_v<B, TypeSeq>;
 
@@ -219,6 +222,12 @@ using type_seq_cat_t = typename detail::TypeSeqCat<TagSeqA, TagSeqB>::type;
 template <class TagSeqA, class TagSeqB, class TagSeqC>
 using type_seq_replace_t =
         typename detail::TypeSeqReplace<TagSeqA, TagSeqB, TagSeqC, detail::TypeSeq<>>::type;
+
+template <class... Tags>
+constexpr bool type_seq_is_unique_v<detail::TypeSeq<Tags...>>
+        = ((type_seq_size_v<type_seq_remove_t<detail::TypeSeq<Tags...>, detail::TypeSeq<Tags>>>
+            == sizeof...(Tags) - 1)
+           && ...);
 
 template <class T>
 using to_type_seq_t = typename detail::ToTypeSeq<T>::type;

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -64,9 +64,7 @@ class DiscreteDomain
     friend class DiscreteDomain;
 
     static_assert(
-            ((type_seq_size_v<type_seq_remove_t<detail::TypeSeq<DDims...>, detail::TypeSeq<DDims>>>
-              == sizeof...(DDims) - 1)
-             && ...),
+            type_seq_is_unique_v<detail::TypeSeq<DDims...>>,
             "The dimensions of a DiscreteDomain must be unique");
 
 public:

--- a/include/ddc/discrete_element.hpp
+++ b/include/ddc/discrete_element.hpp
@@ -162,9 +162,7 @@ class DiscreteElement
     using tags_seq = detail::TypeSeq<Tags...>;
 
     static_assert(
-            ((type_seq_size_v<type_seq_remove_t<tags_seq, detail::TypeSeq<Tags>>>
-              == sizeof...(Tags) - 1)
-             && ...),
+            type_seq_is_unique_v<tags_seq>,
             "The dimensions of a DiscreteElement must be unique");
 
     friend KOKKOS_FUNCTION constexpr std::array<DiscreteElementType, sizeof...(Tags)>& detail::

--- a/include/ddc/discrete_vector.hpp
+++ b/include/ddc/discrete_vector.hpp
@@ -278,9 +278,7 @@ class DiscreteVector : public detail::DiscreteVectorConversionOperators<Discrete
     using tags_seq = detail::TypeSeq<Tags...>;
 
     static_assert(
-            ((type_seq_size_v<type_seq_remove_t<tags_seq, detail::TypeSeq<Tags>>>
-              == sizeof...(Tags) - 1)
-             && ...),
+            type_seq_is_unique_v<tags_seq>,
             "The dimensions of a DiscreteVector must be unique");
 
 private:

--- a/include/ddc/sparse_discrete_domain.hpp
+++ b/include/ddc/sparse_discrete_domain.hpp
@@ -123,11 +123,8 @@ class SparseDiscreteDomain
     friend class SparseDiscreteDomain;
 
     static_assert(
-            ((type_seq_size_v<type_seq_remove_t<detail::TypeSeq<DDims...>, detail::TypeSeq<DDims>>>
-              == sizeof...(DDims) - 1)
-             && ...),
+            type_seq_is_unique_v<detail::TypeSeq<DDims...>>,
             "The dimensions of a SparseDiscreteDomain must be unique");
-
 
 public:
     using discrete_element_type = DiscreteElement<DDims...>;

--- a/include/ddc/strided_discrete_domain.hpp
+++ b/include/ddc/strided_discrete_domain.hpp
@@ -72,9 +72,7 @@ class StridedDiscreteDomain
     friend class StridedDiscreteDomain;
 
     static_assert(
-            ((type_seq_size_v<type_seq_remove_t<detail::TypeSeq<DDims...>, detail::TypeSeq<DDims>>>
-              == sizeof...(DDims) - 1)
-             && ...),
+            type_seq_is_unique_v<detail::TypeSeq<DDims...>>,
             "The dimensions of a StridedDiscreteDomain must be unique");
 
 public:

--- a/tests/type_seq.cpp
+++ b/tests/type_seq.cpp
@@ -93,3 +93,19 @@ TEST(TypeSeqTest, Replace)
     using ExpectedR = ddc::detail::TypeSeq<a, y, c, z, e>;
     EXPECT_TRUE((ddc::type_seq_same_v<R, ExpectedR>));
 }
+
+TEST(TypeSeqTest, IsUnique)
+{
+    using A = ddc::detail::TypeSeq<a, b, c, d, e>;
+    using B = ddc::detail::TypeSeq<>;
+    using C = ddc::detail::TypeSeq<y>;
+    using D = ddc::detail::TypeSeq<y, y>;
+    using E = ddc::detail::TypeSeq<a, b, c, d, b, e>;
+    using F = ddc::detail::TypeSeq<a, b, a, c, b, a, d, b, e, a>;
+    EXPECT_TRUE((ddc::type_seq_is_unique_v<A>));
+    EXPECT_TRUE((ddc::type_seq_is_unique_v<B>));
+    EXPECT_TRUE((ddc::type_seq_is_unique_v<C>));
+    EXPECT_FALSE((ddc::type_seq_is_unique_v<D>));
+    EXPECT_FALSE((ddc::type_seq_is_unique_v<E>));
+    EXPECT_FALSE((ddc::type_seq_is_unique_v<F>));
+}


### PR DESCRIPTION
Currently, there is no check to see if the user passes the same dimension multiple times in the template arguments of `DiscreteElement`, `DiscreteVector` and `[Sparse,Strided]DiscreteDomain`. `DiscreteElement<DDimX, DDimX, DDimX> delem;` compiles without issues.

This PR adds a static assert in these classes to check that the dimensions are unique.