### PR TITLE
Update the spline evaluators' deriv method doc comments

### DIFF
--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -455,7 +455,7 @@ public:
      * obtained via various methods, such as using a SplineBuilder.
      *
      * @param deriv_order A DiscreteElement containing the order of derivation for the dimension of interest.
-     * If the dimension is not present, the order of derivation is considered to be 0. The highest valid order is 1.
+     * If the dimension is not present, the order of derivation is considered to be 0.
      * @param coord_eval The coordinate where the spline is differentiated. Note that only the component along the dimension of interest is used.
      * @param spline_coef A ChunkSpan storing the 1D spline coefficients.
      *
@@ -483,7 +483,7 @@ public:
      * the derivation is performed with the 1D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * @param[in] deriv_order A DiscreteElement containing the order of derivation for the dimension of interest.
-     * If the dimension is not present, the order of derivation is considered to be 0. The highest valid order is 1.
+     * If the dimension is not present, the order of derivation is considered to be 0.
      * @param[out] spline_eval The derivatives of the spline function at the desired coordinates. For practical reasons those are
      * stored in a ChunkSpan defined on a batched_evaluation_domain_type.
      * @param[in] coords_eval The coordinates where the spline is differentiated. Those are
@@ -547,7 +547,7 @@ public:
      * the 1D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * @param[in] deriv_order A DiscreteElement containing the order of derivation for the dimension of interest.
-     * If the dimension is not present, the order of derivation is considered to be 0. The highest valid order is 1.
+     * If the dimension is not present, the order of derivation is considered to be 0.
      * @param[out] spline_eval The derivatives of the spline function at the coordinates.
      * @param[in] spline_coef A ChunkSpan storing the spline coefficients.
      */
@@ -659,17 +659,19 @@ private:
         return eval_no_bc(ddc::DiscreteElement<>(), coord_eval_interest, spline_coef);
     }
 
-    template <class... DDims, class Layout, class... CoordsDims>
+    template <class... DerivDims, class Layout, class... CoordsDims>
     KOKKOS_INLINE_FUNCTION double eval_no_bc(
-            ddc::DiscreteElement<DDims...> const& deriv_order,
+            ddc::DiscreteElement<DerivDims...> const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
             ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         using deriv_dim = ddc::Deriv<continuous_dimension_type>;
         static_assert(
-                sizeof...(DDims) == 0
-                        || type_seq_same_v<detail::TypeSeq<DDims...>, detail::TypeSeq<deriv_dim>>,
+                sizeof...(DerivDims) == 0
+                        || type_seq_same_v<
+                                detail::TypeSeq<DerivDims...>,
+                                detail::TypeSeq<deriv_dim>>,
                 "The only valid dimension for deriv_order is Deriv<Dim>");
 
         ddc::DiscreteElement<bsplines_type> jmin;
@@ -678,7 +680,7 @@ private:
                 vals(vals_ptr.data());
         ddc::Coordinate<continuous_dimension_type> const coord_eval_interest(coord_eval);
 
-        if constexpr (sizeof...(DDims) == 0) {
+        if constexpr (sizeof...(DerivDims) == 0) {
             jmin = ddc::discrete_space<bsplines_type>().eval_basis(vals, coord_eval_interest);
         } else {
             auto const order = deriv_order.uid();

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -1069,8 +1069,7 @@ public:
      * obtained via various methods, such as using a SplineBuilder2D.
      *
      * @param deriv_order A DiscreteElement containing the orders of derivation for each of the dimensions of interest.
-     * If one of the dimensions is not present, its corresponding order of derivation is considered to be 0. The highest
-     * valid order is 2.
+     * If one of the dimensions is not present, its corresponding order of derivation is considered to be 0.
      * @param coord_eval The coordinate where the spline is differentiated. Note that only the components along the dimensions of interest are used.
      * @param spline_coef A ChunkSpan storing the 2D spline coefficients.
      *
@@ -1097,8 +1096,7 @@ public:
      * the differentiation is performed with the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * @param[in] deriv_order A DiscreteElement containing the orders of derivation for each of the dimensions of interest.
-     * If one of the dimensions is not present, its corresponding order of derivation is considered to be 0. The highest
-     * valid order is 2.
+     * If one of the dimensions is not present, its corresponding order of derivation is considered to be 0.
      * @param[out] spline_eval The derivatives of the 2D spline function at the desired coordinates. For practical reasons those are
      * stored in a ChunkSpan defined on a batched_evaluation_domain_type. Note that the coordinates of the
      * points represented by this domain are unused and irrelevant (but the points themselves (DiscreteElement) are used to select
@@ -1168,8 +1166,7 @@ public:
      * the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * @param[in] deriv_order A DiscreteElement containing the orders of derivation for each of the dimensions of interest.
-     * If one of the dimensions is not present, its corresponding order of derivation is considered to be 0. The highest
-     * valid order is 2.
+     * If one of the dimensions is not present, its corresponding order of derivation is considered to be 0.
      * @param[out] spline_eval The derivatives of the 2D spline function at the desired coordinates.
      * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
      */
@@ -1345,20 +1342,20 @@ private:
      * @param[in] coord_eval The coordinate where we want to evaluate.
      * @param[in] splne_coef The B-splines coefficients of the function we want to evaluate.
      */
-    template <class... DDims, class Layout, class... CoordsDims>
+    template <class... DerivDims, class Layout, class... CoordsDims>
     KOKKOS_INLINE_FUNCTION double eval_no_bc(
-            ddc::DiscreteElement<DDims...> const& deriv_order,
+            ddc::DiscreteElement<DerivDims...> const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
             ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         using deriv_dim1 = ddc::Deriv<continuous_dimension_type1>;
         using deriv_dim2 = ddc::Deriv<continuous_dimension_type2>;
-        using deriv_dims = ddc::detail::TypeSeq<DDims...>;
+        using deriv_dims = ddc::detail::TypeSeq<DerivDims...>;
 
         // Check that the tags are valid
         static_assert(
-                (in_tags_v<DDims, ddc::detail::TypeSeq<deriv_dim1, deriv_dim2>> && ...),
+                (in_tags_v<DerivDims, ddc::detail::TypeSeq<deriv_dim1, deriv_dim2>> && ...),
                 "The only valid dimensions for deriv_order are Deriv<Dim1> and Deriv<Dim2>");
 
         ddc::DiscreteElement<bsplines_type1> jmin1;

--- a/include/ddc/kernels/splines/spline_evaluator_3d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_3d.hpp
@@ -584,8 +584,7 @@ public:
      * obtained via various methods, such as using a SplineBuilder3D.
      *
      * @param deriv_order A DiscreteElement containing the orders of derivation for each of the dimensions of interest.
-     * If one of the dimensions is not present, its corresponding order of derivation is considered to be 0. The highest
-     * valid order is 3.
+     * If one of the dimensions is not present, its corresponding order of derivation is considered to be 0.
      * @param coord_eval The coordinate where the spline is differentiated. Note that only the components along the dimensions of interest are used.
      * @param spline_coef A ChunkSpan storing the 3D spline coefficients.
      *
@@ -613,8 +612,7 @@ public:
      * the differentiation is performed with the 3D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * @param[in] deriv_order A DiscreteElement containing the orders of derivation for each of the dimensions of interest.
-     * If one of the dimensions is not present, its corresponding order of derivation is considered to be 0. The highest
-     * valid order is 3.
+     * If one of the dimensions is not present, its corresponding order of derivation is considered to be 0.
      * @param[out] spline_eval The derivatives of the 3D spline function at the desired coordinates. For practical reasons those are
      * stored in a ChunkSpan defined on a batched_evaluation_domain_type.
      * @param[in] coords_eval The coordinates where the spline is differentiated. Those are
@@ -685,8 +683,7 @@ public:
      * the 3D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * @param[in] deriv_order A DiscreteElement containing the orders of derivation for each of the dimensions of interest.
-     * If one of the dimensions is not present, its corresponding order of derivation is considered to be 0. The highest
-     * valid order is 3.
+     * If one of the dimensions is not present, its corresponding order of derivation is considered to be 0.
      * @param[out] spline_eval The derivatives of the 3D spline function at the desired coordinates.
      * @param[in] spline_coef A ChunkSpan storing the 3D spline coefficients.
      */
@@ -904,9 +901,9 @@ private:
      * @param[in] coord_eval The coordinate where we want to evaluate.
      * @param[in] splne_coef The B-splines coefficients of the function we want to evaluate.
      */
-    template <class... DDims, class Layout, class... CoordsDims>
+    template <class... DerivDims, class Layout, class... CoordsDims>
     KOKKOS_INLINE_FUNCTION double eval_no_bc(
-            ddc::DiscreteElement<DDims...> const& deriv_order,
+            ddc::DiscreteElement<DerivDims...> const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
             ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
@@ -914,11 +911,12 @@ private:
         using deriv_dim1 = Deriv<continuous_dimension_type1>;
         using deriv_dim2 = Deriv<continuous_dimension_type2>;
         using deriv_dim3 = Deriv<continuous_dimension_type3>;
-        using deriv_dims = detail::TypeSeq<DDims...>;
+        using deriv_dims = detail::TypeSeq<DerivDims...>;
 
         // Check that the tags are valid
         static_assert(
-                (in_tags_v<DDims, ddc::detail::TypeSeq<deriv_dim1, deriv_dim2, deriv_dim3>> && ...),
+                (in_tags_v<DerivDims, ddc::detail::TypeSeq<deriv_dim1, deriv_dim2, deriv_dim3>>
+                 && ...),
                 "The only valid dimensions for deriv_order are Deriv<Dim1>, Deriv<Dim2> and "
                 "Deriv<Dim3>");
 


### PR DESCRIPTION
This PR updates the doc comments on the `deriv` methods to remove a mention of the highest available derivation order being the dimension of the evaluator (since it's supposed to be the spline degree).

I also renamed a template parameter in the `eval_no_bc` methods across all evaluators.