### PR TITLE
Fix Kokkos IndexType

### DIFF
--- a/include/ddc/for_each.hpp
+++ b/include/ddc/for_each.hpp
@@ -10,17 +10,16 @@
 
 #include <Kokkos_Macros.hpp>
 
-#include "discrete_element.hpp"
 #include "discrete_vector.hpp"
 
 namespace ddc {
 
 namespace detail {
 
-template <class Support, class Element, std::size_t N, class Functor, class... Is>
+template <class Support, std::size_t N, class Functor, class... Is>
 void host_for_each_serial(
         Support const& domain,
-        std::array<Element, N> const& size,
+        std::array<DiscreteVectorElement, N> const& size,
         Functor const& f,
         Is const&... is) noexcept
 {
@@ -28,16 +27,16 @@ void host_for_each_serial(
     if constexpr (I == N) {
         f(domain(typename Support::discrete_vector_type(is...)));
     } else {
-        for (Element ii = 0; ii < size[I]; ++ii) {
+        for (DiscreteVectorElement ii = 0; ii < size[I]; ++ii) {
             host_for_each_serial(domain, size, f, is..., ii);
         }
     }
 }
 
-template <class Support, class Element, std::size_t N, class Functor, class... Is>
+template <class Support, std::size_t N, class Functor, class... Is>
 KOKKOS_FUNCTION void device_for_each_serial(
         Support const& domain,
-        std::array<Element, N> const& size,
+        std::array<DiscreteVectorElement, N> const& size,
         Functor const& f,
         Is const&... is) noexcept
 {
@@ -45,7 +44,7 @@ KOKKOS_FUNCTION void device_for_each_serial(
     if constexpr (I == N) {
         f(domain(typename Support::discrete_vector_type(is...)));
     } else {
-        for (Element ii = 0; ii < size[I]; ++ii) {
+        for (DiscreteVectorElement ii = 0; ii < size[I]; ++ii) {
             device_for_each_serial(domain, size, f, is..., ii);
         }
     }

--- a/include/ddc/parallel_for_each.hpp
+++ b/include/ddc/parallel_for_each.hpp
@@ -12,7 +12,7 @@
 #include <Kokkos_Core.hpp>
 
 #include "ddc_to_kokkos_execution_policy.hpp"
-#include "discrete_element.hpp"
+#include "discrete_vector.hpp"
 
 namespace ddc {
 
@@ -25,7 +25,7 @@ template <class F, class Support, std::size_t... Idx>
 class ForEachKokkosLambdaAdapter<F, Support, std::index_sequence<Idx...>>
 {
     template <std::size_t I>
-    using index_type = DiscreteElementType;
+    using index_type = DiscreteVectorElement;
 
     F m_f;
 
@@ -41,7 +41,7 @@ public:
     template <std::size_t N = sizeof...(Idx), std::enable_if_t<(N == 0), bool> = true>
     KOKKOS_FUNCTION void operator()([[maybe_unused]] index_type<0> unused_id) const
     {
-        m_f(DiscreteElement<>());
+        m_f(m_support(typename Support::discrete_vector_type()));
     }
 
     template <std::size_t N = sizeof...(Idx), std::enable_if_t<(N > 0), bool> = true>
@@ -60,7 +60,7 @@ void for_each_kokkos(
 {
     Kokkos::parallel_for(
             label,
-            ddc_to_kokkos_execution_policy(execution_space, domain),
+            ddc_to_kokkos_execution_policy(execution_space, detail::array(domain.extents())),
             ForEachKokkosLambdaAdapter<
                     Functor,
                     Support,

--- a/include/ddc/parallel_transform_reduce.hpp
+++ b/include/ddc/parallel_transform_reduce.hpp
@@ -12,7 +12,7 @@
 #include <Kokkos_Core.hpp>
 
 #include "ddc_to_kokkos_execution_policy.hpp"
-#include "discrete_element.hpp"
+#include "discrete_vector.hpp"
 #include "reducer.hpp"
 
 namespace ddc {
@@ -93,7 +93,7 @@ template <class Reducer, class Functor, class Support, std::size_t... Idx>
 class TransformReducerKokkosLambdaAdapter<Reducer, Functor, Support, std::index_sequence<Idx...>>
 {
     template <std::size_t I>
-    using index_type = DiscreteElementType;
+    using index_type = DiscreteVectorElement;
 
     Reducer m_reducer;
 
@@ -114,7 +114,7 @@ public:
             [[maybe_unused]] index_type<0> unused_id,
             typename Reducer::value_type& a) const
     {
-        a = m_reducer(a, m_functor(DiscreteElement<>()));
+        a = m_reducer(a, m_functor(m_support(typename Support::discrete_vector_type())));
     }
 
     template <std::size_t N = sizeof...(Idx), std::enable_if_t<(N > 0), bool> = true>
@@ -146,7 +146,7 @@ T transform_reduce_kokkos(
     T result = neutral;
     Kokkos::parallel_reduce(
             label,
-            ddc_to_kokkos_execution_policy(execution_space, domain),
+            ddc_to_kokkos_execution_policy(execution_space, detail::array(domain.extents())),
             TransformReducerKokkosLambdaAdapter<
                     BinaryReductionOp,
                     UnaryTransformOp,

--- a/include/ddc/transform_reduce.hpp
+++ b/include/ddc/transform_reduce.hpp
@@ -12,7 +12,7 @@
 
 #include "detail/macros.hpp"
 
-#include "discrete_element.hpp"
+#include "discrete_vector.hpp"
 
 namespace ddc {
 
@@ -25,11 +25,10 @@ namespace detail {
  *            results of transform, the results of other reduce and neutral.
  * @param[in] transform a unary FunctionObject that will be applied to each element of the input
  *            range. The return type must be acceptable as input to reduce
- * @param[in] dcoords discrete elements from dimensions already in a loop
+ * @param[in] is indices from dimensions already in a loop
  */
 template <
         class Support,
-        class Element,
         std::size_t N,
         class T,
         class BinaryReductionOp,
@@ -37,7 +36,7 @@ template <
         class... Is>
 T host_transform_reduce_serial(
         Support const& domain,
-        std::array<Element, N> const& size,
+        std::array<DiscreteVectorElement, N> const& size,
         [[maybe_unused]] T const neutral,
         BinaryReductionOp const& reduce,
         UnaryTransformOp const& transform,
@@ -49,7 +48,7 @@ T host_transform_reduce_serial(
         return transform(domain(typename Support::discrete_vector_type(is...)));
     } else {
         T result = neutral;
-        for (Element ii = 0; ii < size[I]; ++ii) {
+        for (DiscreteVectorElement ii = 0; ii < size[I]; ++ii) {
             result = reduce(
                     host_transform_reduce_serial(
                             domain,
@@ -73,19 +72,18 @@ T host_transform_reduce_serial(
  *            results of transform, the results of other reduce and neutral.
  * @param[in] transform a unary FunctionObject that will be applied to each element of the input
  *            range. The return type must be acceptable as input to reduce
- * @param[in] dcoords discrete elements from dimensions already in a loop
+ * @param[in] is indices from dimensions already in a loop
  */
 template <
         class Support,
         class T,
-        class Element,
         std::size_t N,
         class BinaryReductionOp,
         class UnaryTransformOp,
         class... Is>
 KOKKOS_FUNCTION T device_transform_reduce_serial(
         Support const& domain,
-        std::array<Element, N> const& size,
+        std::array<DiscreteVectorElement, N> const& size,
         [[maybe_unused]] T const neutral,
         BinaryReductionOp const& reduce,
         UnaryTransformOp const& transform,
@@ -97,7 +95,7 @@ KOKKOS_FUNCTION T device_transform_reduce_serial(
         return transform(domain(typename Support::discrete_vector_type(is...)));
     } else {
         T result = neutral;
-        for (Element ii = 0; ii < size[I]; ++ii) {
+        for (DiscreteVectorElement ii = 0; ii < size[I]; ++ii) {
             result = reduce(
                     device_transform_reduce_serial(
                             domain,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
     chunk.cpp
     chunk_span.cpp
     create_mirror.cpp
+    details.cpp
     discrete_domain.cpp
     discrete_element.cpp
     discrete_space.cpp

--- a/tests/details.cpp
+++ b/tests/details.cpp
@@ -1,0 +1,43 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(DdcToKokkosExecutionPolicy, Dim0)
+{
+    Kokkos::DefaultExecutionSpace const space;
+    auto const kokkos_range = ddc::detail::
+            ddc_to_kokkos_execution_policy(space, std::array<ddc::DiscreteVectorElement, 0> {});
+    EXPECT_EQ(kokkos_range.space(), space);
+    EXPECT_EQ(kokkos_range.begin(), 0);
+    EXPECT_EQ(kokkos_range.end(), 1);
+}
+
+TEST(DdcToKokkosExecutionPolicy, Dim1)
+{
+    ddc::DiscreteVectorElement const n0 = 3;
+    Kokkos::DefaultExecutionSpace const space;
+    auto const kokkos_range = ddc::detail::
+            ddc_to_kokkos_execution_policy(space, std::array<ddc::DiscreteVectorElement, 1> {n0});
+    EXPECT_EQ(kokkos_range.space(), space);
+    EXPECT_EQ(kokkos_range.begin(), 0);
+    EXPECT_EQ(kokkos_range.end(), n0);
+}
+
+TEST(DdcToKokkosExecutionPolicy, Dim2)
+{
+    ddc::DiscreteVectorElement const n0 = 3;
+    ddc::DiscreteVectorElement const n1 = 4;
+    Kokkos::DefaultExecutionSpace const space;
+    auto const kokkos_range = ddc::detail::ddc_to_kokkos_execution_policy(
+            space,
+            std::array<ddc::DiscreteVectorElement, 2> {n0, n1});
+    EXPECT_EQ(kokkos_range.space(), space);
+    EXPECT_EQ(kokkos_range.m_lower[0], 0);
+    EXPECT_EQ(kokkos_range.m_lower[1], 0);
+    EXPECT_EQ(kokkos_range.m_upper[0], n0);
+    EXPECT_EQ(kokkos_range.m_upper[1], n1);
+}


### PR DESCRIPTION
- Fixes a useless implicit conversion `DiscreteElementType` to `DiscreteVectorElement`