### PR TITLE
Fix a norm computation in the 3D evaluator tests

### DIFF
--- a/tests/splines/3d_spline_evaluator_derivatives.cpp
+++ b/tests/splines/3d_spline_evaluator_derivatives.cpp
@@ -169,7 +169,7 @@ void test_deriv(
                         spline_eval_deriv(e) - evaluator.deriv(x, y, z, order1, order2, order3));
             });
 
-    double const max_norm_diff = evaluator.max_norm(order1, order2);
+    double const max_norm_diff = evaluator.max_norm(order1, order2, order3);
 
     SplineErrorBounds<evaluator_type<DDimI1, DDimI2, DDimI3>> const error_bounds(evaluator);
 


### PR DESCRIPTION
There was a typo in the norm computation for the 3D evaluator tests, the 3rd derivation order was not taken into account