### PR TITLE
Remove header-only libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,13 +123,18 @@ endif()
 
 ## The library itself
 
-add_library(ddc_core INTERFACE)
+add_library(ddc_core)
 add_library(DDC::core ALIAS ddc_core)
 configure_file(cmake/config.hpp.in generated/ddc/config.hpp NO_SOURCE_PERMISSIONS @ONLY)
-target_compile_features(ddc_core INTERFACE cxx_std_17)
-target_link_libraries(ddc_core INTERFACE Kokkos::kokkos)
+target_compile_features(ddc_core PUBLIC cxx_std_17)
+target_link_libraries(ddc_core PUBLIC Kokkos::kokkos)
 target_sources(
     ddc_core
+    PRIVATE
+        src/ddc/discrete_space.cpp
+        src/ddc/discrete_element.cpp
+        src/ddc/discrete_vector.cpp
+        src/ddc/print.cpp
     INTERFACE
         FILE_SET HEADERS
             BASE_DIRS src ${CMAKE_CURRENT_BINARY_DIR}/generated
@@ -212,13 +217,22 @@ if("${DDC_BUILD_KERNELS_FFT}")
         endif()
     endif()
 
-    add_library(ddc_fft INTERFACE)
+    add_library(ddc_fft)
     add_library(DDC::fft ALIAS ddc_fft)
-    target_compile_features(ddc_fft INTERFACE cxx_std_17)
-    target_link_libraries(ddc_fft INTERFACE DDC::core Kokkos::kokkos KokkosFFT::fft)
-    target_sources(ddc_fft INTERFACE FILE_SET HEADERS BASE_DIRS src FILES src/ddc/kernels/fft.hpp)
+    target_compile_features(ddc_fft PUBLIC cxx_std_17)
+    target_link_libraries(ddc_fft PUBLIC DDC::core Kokkos::kokkos KokkosFFT::fft)
+    target_sources(
+        ddc_fft
+        INTERFACE FILE_SET HEADERS BASE_DIRS src FILES src/ddc/kernels/fft.hpp
+        PRIVATE src/ddc/kernels/fft.cpp
+    )
 
-    set_target_properties(ddc_fft PROPERTIES EXPORT_NAME fft)
+    set_target_properties(
+        ddc_fft
+        PROPERTIES
+            EXPORT_NAME fft
+            INSTALL_RPATH "$<$<PLATFORM_ID:Linux>:$ORIGIN>;$<$<PLATFORM_ID:Darwin>:@loader_path>"
+    )
     install(TARGETS ddc_fft EXPORT DDCFftTargets FILE_SET HEADERS)
     install(EXPORT DDCFftTargets NAMESPACE DDC:: DESTINATION ${DDC_INSTALL_CMAKEDIR})
 endif()
@@ -258,13 +272,14 @@ if("${DDC_BUILD_KERNELS_SPLINES}")
     target_compile_features(ddc_splines INTERFACE cxx_std_17)
     target_link_libraries(
         ddc_splines
+        INTERFACE DDC::core
         PRIVATE Ginkgo::ginkgo Kokkos::kokkoskernels LAPACKE::LAPACKE
         PUBLIC Kokkos::kokkos
-        INTERFACE DDC::core
     )
     target_sources(
         ddc_splines
         PRIVATE
+            src/ddc/kernels/splines/spline_boundary_conditions.cpp
             src/ddc/kernels/splines/splines_linear_problem.cpp
             src/ddc/kernels/splines/splines_linear_problem_2x2_blocks.cpp
             src/ddc/kernels/splines/splines_linear_problem_3x3_blocks.cpp
@@ -310,7 +325,12 @@ if("${DDC_BUILD_KERNELS_SPLINES}")
     )
 
     install(FILES cmake/FindLAPACKE.cmake DESTINATION ${DDC_INSTALL_CMAKEDIR})
-    set_target_properties(ddc_splines PROPERTIES EXPORT_NAME splines)
+    set_target_properties(
+        ddc_splines
+        PROPERTIES
+            EXPORT_NAME splines
+            INSTALL_RPATH "$<$<PLATFORM_ID:Linux>:$ORIGIN>;$<$<PLATFORM_ID:Darwin>:@loader_path>"
+    )
     install(TARGETS ddc_splines EXPORT DDCSplinesTargets FILE_SET HEADERS)
     install(EXPORT DDCSplinesTargets NAMESPACE DDC:: DESTINATION ${DDC_INSTALL_CMAKEDIR})
 endif()
@@ -320,13 +340,22 @@ endif()
 if("${DDC_BUILD_PDI_WRAPPER}")
     find_package(PDI 1.10.1...<2 REQUIRED COMPONENTS C)
 
-    add_library(ddc_pdi INTERFACE)
+    add_library(ddc_pdi)
     add_library(DDC::pdi ALIAS ddc_pdi)
-    target_compile_features(ddc_pdi INTERFACE cxx_std_17)
-    target_link_libraries(ddc_pdi INTERFACE DDC::core PDI::PDI_C)
-    target_sources(ddc_pdi INTERFACE FILE_SET HEADERS BASE_DIRS src FILES src/ddc/pdi.hpp)
+    target_compile_features(ddc_pdi PUBLIC cxx_std_17)
+    target_link_libraries(ddc_pdi PUBLIC DDC::core PDI::PDI_C)
+    target_sources(
+        ddc_pdi
+        INTERFACE FILE_SET HEADERS BASE_DIRS src FILES src/ddc/pdi.hpp
+        PRIVATE src/ddc/pdi.cpp
+    )
 
-    set_target_properties(ddc_pdi PROPERTIES EXPORT_NAME pdi)
+    set_target_properties(
+        ddc_pdi
+        PROPERTIES
+            EXPORT_NAME pdi
+            INSTALL_RPATH "$<$<PLATFORM_ID:Linux>:$ORIGIN>;$<$<PLATFORM_ID:Darwin>:@loader_path>"
+    )
     install(TARGETS ddc_pdi EXPORT DDCPdiTargets FILE_SET HEADERS)
     install(EXPORT DDCPdiTargets NAMESPACE DDC:: DESTINATION ${DDC_INSTALL_CMAKEDIR})
 endif()

--- a/src/ddc/discrete_element.cpp
+++ b/src/ddc/discrete_element.cpp
@@ -1,0 +1,27 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <ostream>
+
+#include "discrete_element.hpp"
+
+namespace ddc::detail {
+
+void print_discrete_element(
+        std::ostream& os,
+        DiscreteElementType const* const data,
+        std::size_t const n)
+{
+    os << '(';
+    if (n > 0) {
+        os << data[0];
+        for (std::size_t i = 1; i < n; ++i) {
+            os << ", " << data[i];
+        }
+    }
+    os << ')';
+}
+
+} // namespace ddc::detail

--- a/src/ddc/discrete_element.hpp
+++ b/src/ddc/discrete_element.hpp
@@ -6,7 +6,7 @@
 
 #include <array>
 #include <cstddef>
-#include <ostream>
+#include <iosfwd>
 #include <type_traits>
 #include <utility>
 
@@ -317,20 +317,18 @@ public:
     }
 };
 
-inline std::ostream& operator<<(std::ostream& out, DiscreteElement<> const&)
-{
-    out << "()";
-    return out;
-}
+namespace detail {
 
-template <class Head, class... Tags>
-std::ostream& operator<<(std::ostream& out, DiscreteElement<Head, Tags...> const& arr)
+void print_discrete_element(std::ostream& os, DiscreteElementType const* data, std::size_t n);
+
+} // namespace detail
+
+template <class... Tags>
+std::ostream& operator<<(std::ostream& os, DiscreteElement<Tags...> const& arr)
 {
-    out << "(";
-    out << uid<Head>(arr);
-    ((out << ", " << uid<Tags>(arr)), ...);
-    out << ")";
-    return out;
+    std::array const std_arr = detail::array(arr);
+    detail::print_discrete_element(os, std_arr.data(), std_arr.size());
+    return os;
 }
 
 

--- a/src/ddc/discrete_space.cpp
+++ b/src/ddc/discrete_space.cpp
@@ -1,0 +1,71 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <cassert>
+#include <functional>
+#include <map>
+#include <optional>
+#include <ostream>
+#include <string>
+
+#include <Kokkos_Core.hpp>
+
+#if defined(KOKKOS_ENABLE_CUDA)
+#    include <sstream>
+
+#    include <cuda.h>
+#elif defined(KOKKOS_ENABLE_HIP)
+#    include <sstream>
+
+#    include <hip/hip_runtime.h>
+#endif
+
+namespace ddc::detail {
+
+#if defined(KOKKOS_ENABLE_CUDA)
+void device_throw_on_error(
+        cudaError_t const err,
+        const char* const func,
+        const char* const file,
+        const int line)
+{
+    if (err != cudaSuccess) {
+        std::stringstream ss;
+        ss << "CUDA Runtime Error at: " << file << ":" << line << "\n";
+        ss << cudaGetErrorString(err) << " " << func << "\n";
+        throw std::runtime_error(ss.str());
+    }
+}
+#elif defined(KOKKOS_ENABLE_HIP)
+void device_throw_on_error(
+        hipError_t const err,
+        const char* const func,
+        const char* const file,
+        const int line)
+{
+    if (err != hipSuccess) {
+        std::stringstream ss;
+        ss << "HIP Runtime Error at: " << file << ":" << line << "\n";
+        ss << hipGetErrorString(err) << " " << func << "\n";
+        throw std::runtime_error(ss.str());
+    }
+}
+#endif
+
+// Global CPU variable storing resetters. Required to correctly free data.
+std::optional<std::map<std::string, std::function<void()>>> g_discretization_store;
+
+void display_discretization_store(std::ostream& os)
+{
+    if (g_discretization_store) {
+        os << "The host discretization store is initialized:\n";
+        for (auto const& [key, value] : *g_discretization_store) {
+            os << " - " << key << "\n";
+        }
+    } else {
+        os << "The host discretization store is not initialized:\n";
+    }
+}
+
+} // namespace ddc::detail

--- a/src/ddc/discrete_space.hpp
+++ b/src/ddc/discrete_space.hpp
@@ -7,9 +7,9 @@
 #include <cassert>
 #include <cstddef>
 #include <functional>
+#include <iosfwd>
 #include <map>
 #include <optional>
-#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -23,12 +23,8 @@
 #include "detail/macros.hpp"
 
 #if defined(KOKKOS_ENABLE_CUDA)
-#    include <sstream>
-
 #    include <cuda.h>
 #elif defined(KOKKOS_ENABLE_HIP)
-#    include <sstream>
-
 #    include <hip/hip_runtime.h>
 #endif
 
@@ -42,33 +38,17 @@ namespace ddc {
 namespace detail {
 
 #if defined(KOKKOS_ENABLE_CUDA)
-inline void device_throw_on_error(
+void device_throw_on_error(
         cudaError_t const err,
         const char* const func,
         const char* const file,
-        const int line)
-{
-    if (err != cudaSuccess) {
-        std::stringstream ss;
-        ss << "CUDA Runtime Error at: " << file << ":" << line << "\n";
-        ss << cudaGetErrorString(err) << " " << func << "\n";
-        throw std::runtime_error(ss.str());
-    }
-}
+        const int line);
 #elif defined(KOKKOS_ENABLE_HIP)
-inline void device_throw_on_error(
+void device_throw_on_error(
         hipError_t const err,
         const char* const func,
         const char* const file,
-        const int line)
-{
-    if (err != hipSuccess) {
-        std::stringstream ss;
-        ss << "HIP Runtime Error at: " << file << ":" << line << "\n";
-        ss << hipGetErrorString(err) << " " << func << "\n";
-        throw std::runtime_error(ss.str());
-    }
-}
+        const int line);
 #endif
 
 template <class DDim, class MemorySpace>
@@ -111,7 +91,7 @@ public:
 };
 
 // Global CPU variable storing resetters. Required to correctly free data.
-inline std::optional<std::map<std::string, std::function<void()>>> g_discretization_store;
+extern std::optional<std::map<std::string, std::function<void()>>> g_discretization_store;
 
 // Global CPU variable owning discrete spaces data for CPU and GPU
 template <class DDim>
@@ -134,17 +114,7 @@ SYCL_EXTERNAL inline sycl::ext::oneapi::experimental::device_global<
         g_discrete_space_device;
 #endif
 
-inline void display_discretization_store(std::ostream& os)
-{
-    if (g_discretization_store) {
-        os << "The host discretization store is initialized:\n";
-        for (auto const& [key, value] : *g_discretization_store) {
-            os << " - " << key << "\n";
-        }
-    } else {
-        os << "The host discretization store is not initialized:\n";
-    }
-}
+void display_discretization_store(std::ostream& os);
 
 template <class Tuple, std::size_t... Ids>
 auto extract_after(Tuple&& t, std::index_sequence<Ids...>)

--- a/src/ddc/discrete_vector.cpp
+++ b/src/ddc/discrete_vector.cpp
@@ -1,0 +1,27 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <ostream>
+
+#include "discrete_vector.hpp"
+
+namespace ddc::detail {
+
+void print_discrete_vector(
+        std::ostream& os,
+        DiscreteVectorElement const* const data,
+        std::size_t const n)
+{
+    os << '(';
+    if (n > 0) {
+        os << data[0];
+        for (std::size_t i = 1; i < n; ++i) {
+            os << ", " << data[i];
+        }
+    }
+    os << ')';
+}
+
+} // namespace ddc::detail

--- a/src/ddc/discrete_vector.hpp
+++ b/src/ddc/discrete_vector.hpp
@@ -6,7 +6,7 @@
 
 #include <array>
 #include <cstddef>
-#include <ostream>
+#include <iosfwd>
 #include <type_traits>
 #include <utility>
 
@@ -474,20 +474,18 @@ KOKKOS_FUNCTION constexpr bool operator<(DiscreteVector<Tag> const& lhs, Integra
     return lhs.value() < rhs;
 }
 
-inline std::ostream& operator<<(std::ostream& out, DiscreteVector<> const&)
-{
-    out << "()";
-    return out;
-}
+namespace detail {
 
-template <class Head, class... Tags>
-std::ostream& operator<<(std::ostream& out, DiscreteVector<Head, Tags...> const& arr)
+void print_discrete_vector(std::ostream& os, DiscreteVectorElement const* data, std::size_t n);
+
+} // namespace detail
+
+template <class... Tags>
+std::ostream& operator<<(std::ostream& os, DiscreteVector<Tags...> const& arr)
 {
-    out << "(";
-    out << get<Head>(arr);
-    ((out << ", " << get<Tags>(arr)), ...);
-    out << ")";
-    return out;
+    std::array const std_arr = detail::array(arr);
+    detail::print_discrete_vector(os, std_arr.data(), std_arr.size());
+    return os;
 }
 
 } // namespace ddc

--- a/src/ddc/kernels/fft.cpp
+++ b/src/ddc/kernels/fft.cpp
@@ -1,0 +1,36 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <stdexcept>
+
+#include <KokkosFFT.hpp>
+
+#include "fft.hpp"
+
+namespace ddc::detail::fft {
+
+KokkosFFT::Normalization ddc_fft_normalization_to_kokkos_fft(
+        FFT_Normalization const ddc_fft_normalization)
+{
+    if (ddc_fft_normalization == ddc::FFT_Normalization::OFF
+        || ddc_fft_normalization == ddc::FFT_Normalization::FULL) {
+        return KokkosFFT::Normalization::none;
+    }
+
+    if (ddc_fft_normalization == ddc::FFT_Normalization::FORWARD) {
+        return KokkosFFT::Normalization::forward;
+    }
+
+    if (ddc_fft_normalization == ddc::FFT_Normalization::BACKWARD) {
+        return KokkosFFT::Normalization::backward;
+    }
+
+    if (ddc_fft_normalization == ddc::FFT_Normalization::ORTHO) {
+        return KokkosFFT::Normalization::ortho;
+    }
+
+    throw std::runtime_error("ddc::FFT_Normalization not handled");
+}
+
+} // namespace ddc::detail::fft

--- a/src/ddc/kernels/fft.hpp
+++ b/src/ddc/kernels/fft.hpp
@@ -103,28 +103,8 @@ KokkosFFT::axis_type<sizeof...(DDimX)> axes()
             static_cast<int>(ddc::type_seq_rank_v<DDimX, ddc::detail::TypeSeq<DDimX...>>)...};
 }
 
-inline KokkosFFT::Normalization ddc_fft_normalization_to_kokkos_fft(
-        FFT_Normalization const ddc_fft_normalization)
-{
-    if (ddc_fft_normalization == ddc::FFT_Normalization::OFF
-        || ddc_fft_normalization == ddc::FFT_Normalization::FULL) {
-        return KokkosFFT::Normalization::none;
-    }
-
-    if (ddc_fft_normalization == ddc::FFT_Normalization::FORWARD) {
-        return KokkosFFT::Normalization::forward;
-    }
-
-    if (ddc_fft_normalization == ddc::FFT_Normalization::BACKWARD) {
-        return KokkosFFT::Normalization::backward;
-    }
-
-    if (ddc_fft_normalization == ddc::FFT_Normalization::ORTHO) {
-        return KokkosFFT::Normalization::ortho;
-    }
-
-    throw std::runtime_error("ddc::FFT_Normalization not handled");
-}
+KokkosFFT::Normalization ddc_fft_normalization_to_kokkos_fft(
+        FFT_Normalization ddc_fft_normalization);
 
 template <class T>
 class ScaleFn

--- a/src/ddc/kernels/splines/spline_boundary_conditions.cpp
+++ b/src/ddc/kernels/splines/spline_boundary_conditions.cpp
@@ -1,0 +1,33 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <ostream>
+#include <stdexcept>
+
+#include "spline_boundary_conditions.hpp"
+
+namespace ddc {
+
+std::ostream& operator<<(std::ostream& os, ddc::BoundCond const bc)
+{
+    if (bc == ddc::BoundCond::PERIODIC) {
+        return os << "PERIODIC";
+    }
+
+    if (bc == ddc::BoundCond::HERMITE) {
+        return os << "HERMITE";
+    }
+
+    if (bc == ddc::BoundCond::HOMOGENEOUS_HERMITE) {
+        return os << "HOMOGENEOUS_HERMITE";
+    }
+
+    if (bc == ddc::BoundCond::GREVILLE) {
+        return os << "GREVILLE";
+    }
+
+    throw std::runtime_error("ddc::BoundCond not handled");
+}
+
+} // namespace ddc

--- a/src/ddc/kernels/splines/spline_boundary_conditions.hpp
+++ b/src/ddc/kernels/splines/spline_boundary_conditions.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <cstddef>
-#include <ostream>
+#include <iosfwd>
 #include <stdexcept>
 
 namespace ddc {
@@ -23,31 +22,12 @@ enum class BoundCond {
 /**
  * @brief Prints a boundary condition in a std::ostream.
  *
- * @param out The stream in which the boundary condition is printed.
- * @param degree The boundary condition.
+ * @param os The stream in which the boundary condition is printed.
+ * @param bc The boundary condition.
  *
  * @return The stream in which the boundary condition is printed.
  **/
-static inline std::ostream& operator<<(std::ostream& out, ddc::BoundCond const bc)
-{
-    if (bc == ddc::BoundCond::PERIODIC) {
-        return out << "PERIODIC";
-    }
-
-    if (bc == ddc::BoundCond::HERMITE) {
-        return out << "HERMITE";
-    }
-
-    if (bc == ddc::BoundCond::HOMOGENEOUS_HERMITE) {
-        return out << "HOMOGENEOUS_HERMITE";
-    }
-
-    if (bc == ddc::BoundCond::GREVILLE) {
-        return out << "GREVILLE";
-    }
-
-    throw std::runtime_error("ddc::BoundCond not handled");
-}
+std::ostream& operator<<(std::ostream& os, ddc::BoundCond bc);
 
 /**
  * @brief Return the number of equations needed to describe a given boundary condition.

--- a/src/ddc/pdi.cpp
+++ b/src/ddc/pdi.cpp
@@ -1,0 +1,35 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <pdi.h>
+
+#include "pdi.hpp"
+
+namespace ddc {
+
+char const* PdiEvent::store_name(std::string&& name)
+{
+    return m_names.emplace_back(std::move(name)).c_str();
+}
+
+char const* PdiEvent::store_name(std::string const& name)
+{
+    return m_names.emplace_back(name).c_str();
+}
+
+PdiEvent::PdiEvent(std::string const& event_name) : m_event_name(event_name) {}
+
+PdiEvent::~PdiEvent() noexcept
+{
+    PDI_event(m_event_name.c_str());
+    for (std::string const& one_name : m_names) {
+        PDI_reclaim(one_name.c_str());
+    }
+}
+
+} // namespace ddc

--- a/src/ddc/pdi.hpp
+++ b/src/ddc/pdi.hpp
@@ -36,15 +36,9 @@ class PdiEvent
 
     std::list<std::any> m_metadata;
 
-    char const* store_name(std::string&& name)
-    {
-        return m_names.emplace_back(std::move(name)).c_str();
-    }
+    char const* store_name(std::string&& name);
 
-    char const* store_name(std::string const& name)
-    {
-        return m_names.emplace_back(name).c_str();
-    }
+    char const* store_name(std::string const& name);
 
     template <class T>
     T* store_scalar(T t)
@@ -61,19 +55,13 @@ class PdiEvent
     }
 
 public:
-    explicit PdiEvent(std::string const& event_name) : m_event_name(event_name) {}
+    explicit PdiEvent(std::string const& event_name);
 
     PdiEvent(PdiEvent const& rhs) = delete;
 
     PdiEvent(PdiEvent&& rhs) noexcept = delete;
 
-    ~PdiEvent() noexcept
-    {
-        PDI_event(m_event_name.c_str());
-        for (std::string const& one_name : m_names) {
-            PDI_reclaim(one_name.c_str());
-        }
-    }
+    ~PdiEvent() noexcept;
 
     PdiEvent& operator=(PdiEvent const& rhs) = delete;
 

--- a/src/ddc/print.cpp
+++ b/src/ddc/print.cpp
@@ -1,0 +1,64 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <cstdlib>
+#include <memory>
+#include <ostream>
+
+#include <Kokkos_Macros.hpp>
+
+#include "discrete_vector.hpp"
+#include "print.hpp"
+
+#if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
+#    include <cxxabi.h>
+#endif
+
+namespace ddc::detail {
+
+void print_demangled_type_name(std::ostream& os, char const* const mangled_name)
+{
+#if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
+    int status;
+
+    std::unique_ptr<char, decltype(std::free)*> const
+            demangled_name(abi::__cxa_demangle(mangled_name, nullptr, nullptr, &status), std::free);
+    if (status != 0) {
+        os << "Error demangling dimension name: " << status;
+        return;
+    }
+
+    os << demangled_name.get();
+#else
+    os << mangled_name;
+#endif
+}
+
+void print_single_dim_name(
+        std::ostream& os,
+        char const* const dim,
+        DiscreteVectorElement const size)
+{
+    print_demangled_type_name(os, dim);
+    os << '(' << size << ')';
+}
+
+void print_dim_name(
+        std::ostream& os,
+        char const* const* const dims,
+        DiscreteVectorElement const* const sizes,
+        std::size_t const n)
+{
+    if (n == 0) {
+        os << "Scalar";
+    } else {
+        print_single_dim_name(os, dims[0], sizes[0]);
+        for (std::size_t i = 1; i < n; ++i) {
+            os << "×";
+            print_single_dim_name(os, dims[i], sizes[i]);
+        }
+    }
+}
+
+} // namespace ddc::detail

--- a/src/ddc/print.hpp
+++ b/src/ddc/print.hpp
@@ -268,7 +268,7 @@ void print_dim_name(
 template <class... Dims>
 void print_dim_name(std::ostream& os, DiscreteVector<Dims...> const& dd)
 {
-    std::array const names {typeid(Dims).name()...};
+    std::array<char const*, sizeof...(Dims)> const names {typeid(Dims).name()...};
     std::array const std_dd = detail::array(dd);
     print_dim_name(os, names.data(), std_dd.data(), std_dd.size());
 }

--- a/src/ddc/print.hpp
+++ b/src/ddc/print.hpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <memory>
 #include <ostream>
 #include <sstream>
 #include <type_traits>
@@ -17,10 +16,6 @@
 
 #include "chunk_span.hpp"
 #include "discrete_vector.hpp"
-
-#if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
-#    include <cxxabi.h>
-#endif
 
 namespace ddc {
 namespace detail {
@@ -262,43 +257,20 @@ public:
     }
 };
 
-inline void print_demangled_type_name(std::ostream& os, char const* const mangled_name)
-{
-#if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
-    int status;
+void print_demangled_type_name(std::ostream& os, char const* mangled_name);
 
-    std::unique_ptr<char, decltype(std::free)*> const
-            demangled_name(abi::__cxa_demangle(mangled_name, nullptr, nullptr, &status), std::free);
-    if (status != 0) {
-        os << "Error demangling dimension name: " << status;
-        return;
-    }
-
-    os << demangled_name.get();
-#else
-    os << mangled_name;
-#endif
-}
-
-inline void print_single_dim_name(
+void print_dim_name(
         std::ostream& os,
-        std::type_info const& dim,
-        DiscreteVectorElement const size)
-{
-    print_demangled_type_name(os, dim.name());
-    os << '(' << size << ')';
-}
+        char const* const* dims,
+        DiscreteVectorElement const* sizes,
+        std::size_t n);
 
-inline void print_dim_name(std::ostream& os, DiscreteVector<> const&)
+template <class... Dims>
+void print_dim_name(std::ostream& os, DiscreteVector<Dims...> const& dd)
 {
-    os << "Scalar";
-}
-
-template <class Dim0, class... Dims>
-void print_dim_name(std::ostream& os, DiscreteVector<Dim0, Dims...> const& dd)
-{
-    print_single_dim_name(os, typeid(Dim0), get<Dim0>(dd));
-    ((os << "×", print_single_dim_name(os, typeid(Dims), get<Dims>(dd))), ...);
+    std::array const names {typeid(Dims).name()...};
+    std::array const std_dd = detail::array(dd);
+    print_dim_name(os, names.data(), std_dd.data(), std_dd.size());
 }
 
 } // namespace detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,12 @@ target_compile_features(ddc_gtest_main PRIVATE cxx_std_17)
 target_link_libraries(ddc_gtest_main PRIVATE DDC::core GTest::gtest)
 target_sources(ddc_gtest_main PRIVATE main.cpp)
 
+add_executable(ddc_tests_uninitialized)
+target_compile_features(ddc_tests_uninitialized PRIVATE cxx_std_17)
+target_link_libraries(ddc_tests_uninitialized PRIVATE DDC::core GTest::gtest_main)
+target_sources(ddc_tests_uninitialized PRIVATE discrete_space_uninitialized.cpp)
+gtest_discover_tests(ddc_tests_uninitialized DISCOVERY_MODE PRE_TEST)
+
 add_executable(
     ddc_tests
     aligned_allocator.cpp

--- a/tests/discrete_element.cpp
+++ b/tests/discrete_element.cpp
@@ -241,6 +241,14 @@ TEST(DiscreteElementXYZTest, RightExternalBinaryOperatorMinus)
     EXPECT_EQ(ixyz2.uid<DDimZ>(), uid_z);
 }
 
+TEST(DiscreteElement0DTest, StreamOperator)
+{
+    ddc::DiscreteElement<> const i0d {};
+    std::stringstream ss;
+    ss << i0d;
+    EXPECT_EQ(ss.str(), "()");
+}
+
 TEST(DiscreteElementXYZTest, StreamOperator)
 {
     ddc::DiscreteElementType const uid_x = 7;

--- a/tests/discrete_space.cpp
+++ b/tests/discrete_space.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <sstream>
 #include <stdexcept>
 
 #include <ddc/ddc.hpp>
@@ -42,4 +43,29 @@ TEST(DiscreteSpace, Initialization)
     EXPECT_EQ(
             static_cast<void const*>(&ddc::discrete_space<DDimX>()),
             static_cast<void const*>(&ddc::host_discrete_space<DDimX>()));
+}
+
+TEST(DiscreteSpace, DisplayDiscretizationStore)
+{
+    ddc::init_discrete_space<DDimX>(DDimX::template init<DDimX>(
+            ddc::Coordinate<DimX>(0),
+            ddc::Coordinate<DimX>(1),
+            ddc::DiscreteVector<DDimX>(2)));
+    std::stringstream ss;
+    ddc::detail::display_discretization_store(ss);
+#if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
+    EXPECT_EQ(
+            ss.str(),
+            "The host discretization store is initialized:\n - "
+            "N49anonymous_namespace_workaround_discrete_space_cpp5DDimXE\n");
+
+#elif defined(KOKKOS_COMPILER_MSVC)
+    EXPECT_EQ(
+            ss.str(),
+            "The host discretization store is initialized:\n - "
+            "struct anonymous_namespace_workaround_discrete_space_cpp::DDimX\n");
+
+#else
+    GTEST_SKIP();
+#endif
 }

--- a/tests/discrete_space_uninitialized.cpp
+++ b/tests/discrete_space_uninitialized.cpp
@@ -1,0 +1,16 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <sstream>
+
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(DiscreteSpace, UninitializedDisplayDiscretizationStore)
+{
+    std::stringstream ss;
+    ddc::detail::display_discretization_store(ss);
+    EXPECT_EQ(ss.str(), "The host discretization store is not initialized:\n");
+}

--- a/tests/discrete_vector.cpp
+++ b/tests/discrete_vector.cpp
@@ -206,6 +206,14 @@ TEST(DiscreteVectorTest, ExternalBinaryOperatorMinus)
     EXPECT_EQ(ddc::get<DDimZ>(result5), dv_z - dv2_z);
 }
 
+TEST(DiscreteVector0DTest, StreamOperator)
+{
+    ddc::DiscreteVector<> const dv0d {};
+    std::stringstream ss;
+    ss << dv0d;
+    EXPECT_EQ(ss.str(), "()");
+}
+
 TEST(DiscreteVectorTest, StreamOperator)
 {
     ddc::DiscreteVectorElement const dv_x = 7;

--- a/tests/print.cpp
+++ b/tests/print.cpp
@@ -270,7 +270,28 @@ TEST(Print, CheckOutput3d)
 }
 
 #if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
-void TestPrintTestMetadata()
+TEST(Print, CheckMetadata0d)
+{
+    using ElementType = double;
+
+    ddc::DiscreteDomain<> const domain_0d;
+
+    ddc::Chunk chunk("chunk", domain_0d, ddc::DeviceAllocator<ElementType>());
+    ddc::ChunkSpan const chunk_span = chunk.span_view();
+
+    {
+        std::stringstream ss;
+        print_type_info(ss, chunk_span);
+        EXPECT_THAT(
+                ss.str(),
+                testing::MatchesRegex(
+                        "Scalar\n"
+                        "ddc::ChunkSpan<double, ddc::DiscreteDomain<>"
+                        ", Kokkos::layout_.+, Kokkos::.+Space>\n"));
+    }
+}
+
+void TestPrintTestMetadata2d()
 {
     using ElementType = double;
 
@@ -302,8 +323,8 @@ void TestPrintTestMetadata()
     }
 }
 
-TEST(Print, CheckMetadata)
+TEST(Print, CheckMetadata2d)
 {
-    TestPrintTestMetadata();
+    TestPrintTestMetadata2d();
 }
 #endif

--- a/tests/splines/CMakeLists.txt
+++ b/tests/splines/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
     bsplines.cpp
     knots_as_interpolation_points.cpp
     splines_linear_problem.cpp
+    spline_boundary_conditions.cpp
     spline_builder.cpp
     spline_traits.cpp
     view.cpp

--- a/tests/splines/spline_boundary_conditions.cpp
+++ b/tests/splines/spline_boundary_conditions.cpp
@@ -1,0 +1,33 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <sstream>
+#include <stdexcept>
+
+#include <ddc/ddc.hpp>
+#include <ddc/kernels/splines.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(SplineBoundaryConditions, StreamOperator)
+{
+    std::stringstream ss;
+    ss << ddc::BoundCond::GREVILLE;
+    EXPECT_EQ("GREVILLE", ss.str());
+
+    ss.str("");
+    ss << ddc::BoundCond::HERMITE;
+    EXPECT_EQ("HERMITE", ss.str());
+
+    ss.str("");
+    ss << ddc::BoundCond::HOMOGENEOUS_HERMITE;
+    EXPECT_EQ("HOMOGENEOUS_HERMITE", ss.str());
+
+    ss.str("");
+    ss << ddc::BoundCond::PERIODIC;
+    EXPECT_EQ("PERIODIC", ss.str());
+
+    ss.str("");
+    EXPECT_THROW((ss << static_cast<ddc::BoundCond>(-1)), std::runtime_error);
+}


### PR DESCRIPTION
Main changes:
- remove header-only libraries

Secondary changes:
- increase code coverage
- fix implementation of `print_dim_name` in the 0d case