### PR TITLE
Add save_npy function

### DIFF
--- a/.github/workflows/python-checks.yaml
+++ b/.github/workflows/python-checks.yaml
@@ -40,9 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Install dependencies
-        run: |
-          pipx install pylint~=4.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.14'
+      - run: pip install numpy pylint~=4.0
       - name: Analysing the code with pylint
         run: |
           pylint $(git ls-files '*.py' ':!benchmarks/splines_plot.py')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ target_sources(
         src/ddc/non_uniform_point_sampling.cpp
         src/ddc/periodic_sampling.cpp
         src/ddc/print.cpp
+        src/ddc/save_npy.cpp
         src/ddc/scope_guard.cpp
         src/ddc/uniform_point_sampling.cpp
     PUBLIC
@@ -183,6 +184,7 @@ target_sources(
                 src/ddc/print.hpp
                 src/ddc/real_type.hpp
                 src/ddc/reducer.hpp
+                src/ddc/save_npy.hpp
                 src/ddc/scope_guard.hpp
                 src/ddc/sparse_discrete_domain.hpp
                 src/ddc/strided_discrete_domain.hpp

--- a/docker/latest/spack-env/spack-cpu.yaml
+++ b/docker/latest/spack-env/spack-cpu.yaml
@@ -44,6 +44,8 @@ spack:
     - 'pdiplugin-user-code@1.10.1:1.10'
     - 'pdiplugin-trace@1.10.1:1.10'
     - 'py-gcovr@8.6'
+    - 'py-numpy@2.4'
+    - 'py-pytest@9.0'
   view:
     default:
       root: .spack-env/view

--- a/docker/oldest/spack-env/spack-cpu.yaml
+++ b/docker/oldest/spack-env/spack-cpu.yaml
@@ -43,6 +43,8 @@ spack:
     - 'pdiplugin-decl-hdf5@1.10.1:1.10'
     - 'pdiplugin-user-code@1.10.1:1.10'
     - 'pdiplugin-trace@1.10.1:1.10'
+    - 'py-numpy@1.24'
+    - 'py-pytest@8.4'
   view:
     default:
       root: .spack-env/view

--- a/src/ddc/ddc.hpp
+++ b/src/ddc/ddc.hpp
@@ -83,3 +83,4 @@ namespace ddc {
 
 // Output
 #include "print.hpp"
+#include "save_npy.hpp"

--- a/src/ddc/save_npy.cpp
+++ b/src/ddc/save_npy.cpp
@@ -1,0 +1,107 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "save_npy.hpp"
+
+namespace ddc::detail {
+
+NpyByteOrder get_byte_order(std::size_t const itemsize) noexcept
+{
+    if (itemsize == 1) {
+        return NpyByteOrder::not_applicable;
+    }
+
+    if (std::endian::native == std::endian::little) {
+        return NpyByteOrder::little_endian;
+    }
+
+    if (std::endian::native == std::endian::big) {
+        return NpyByteOrder::big_endian;
+    }
+
+    return NpyByteOrder::not_applicable;
+}
+
+void write_le(std::ostream& os, std::uint16_t const value_u16)
+{
+    constexpr unsigned int mask = 0xFFU;
+
+    unsigned int const value_u = value_u16;
+
+    std::array<char, 2> bytes;
+    bytes[0] = value_u & mask;
+    bytes[1] = (value_u >> 8U) & mask;
+
+    os.write(bytes.data(), sizeof(value_u16));
+}
+
+std::string NpyDtype::str() const
+{
+    return std::string(1, static_cast<char>(byte_order)) + static_cast<char>(kind)
+           + std::to_string(itemsize);
+}
+
+// See specification at https://numpy.org/neps/nep-0001-npy-format.html#format-specification-version-1-0
+void save_npy(std::ostream& os, NpyArrayView const& view)
+{
+    // Build shape string: (d0, d1, ..., dN,)
+    std::string shape_str = "(";
+    for (std::size_t const ext : view.shape) {
+        shape_str += std::to_string(ext);
+        shape_str += ", ";
+    }
+    shape_str += ")";
+
+    std::string const header_dict
+            = std::string("{'descr': '") + view.dtype.str() + "', 'fortran_order': "
+              + (view.fortran_order ? "True" : "False") + ", 'shape': " + shape_str + ", }";
+
+    // Pad header to a multiple of 16
+    std::size_t const non_padded_header_len = header_dict.size() + 1;
+    // magic(6) + major(1) + minor(1) + header_len(2) + header
+    std::size_t const padding = 16 - (6 + 1 + 1 + 2 + non_padded_header_len) % 16;
+    if (!std::in_range<std::uint16_t>(non_padded_header_len + padding)) {
+        throw std::runtime_error("save_npy: header too large for npy v1.0.");
+    }
+    auto const header_len = static_cast<std::uint16_t>(non_padded_header_len + padding);
+
+    // magic string
+    os.write("\x93NUMPY", 6);
+    // major version
+    os.put(1);
+    // minor version
+    os.put(0);
+    // header length in little-endian
+    write_le(os, header_len);
+    // header + padding + newline
+    os.write(header_dict.data(), header_dict.size());
+    os.write("               ", padding);
+    os.put('\n');
+
+    // Raw data
+    std::size_t const n_elems
+            = std::accumulate(view.shape.begin(), view.shape.end(), 1ULL, std::multiplies<> {});
+    os.write(reinterpret_cast<char const*>(view.data), n_elems * view.dtype.itemsize);
+}
+
+void save_npy(std::filesystem::path const& filename, NpyArrayView const& view)
+{
+    std::ofstream file(filename, std::ios::binary);
+    file.exceptions(std::ios::failbit | std::ios::badbit);
+
+    save_npy(file, view);
+}
+
+} // namespace ddc::detail

--- a/src/ddc/save_npy.cpp
+++ b/src/ddc/save_npy.cpp
@@ -73,7 +73,7 @@ void save_npy(std::ostream& os, NpyArrayView const& view)
     // magic(6) + major(1) + minor(1) + header_len(2) + header
     std::size_t const alignment = 16;
     std::size_t const remainder = (6 + 1 + 1 + 2 + non_padded_header_len) % alignment;
-    std::size_t const padding = remainder == 0 ? 0 : alignment - remainder;
+    std::size_t const padding = (alignment - remainder) % alignment;
     if (!std::in_range<std::uint16_t>(non_padded_header_len + padding)) {
         throw std::runtime_error("save_npy: header too large for npy v1.0.");
     }

--- a/src/ddc/save_npy.cpp
+++ b/src/ddc/save_npy.cpp
@@ -71,7 +71,9 @@ void save_npy(std::ostream& os, NpyArrayView const& view)
     // Pad header to a multiple of 16
     std::size_t const non_padded_header_len = header_dict.size() + 1;
     // magic(6) + major(1) + minor(1) + header_len(2) + header
-    std::size_t const padding = 16 - (6 + 1 + 1 + 2 + non_padded_header_len) % 16;
+    std::size_t const alignment = 16;
+    std::size_t const remainder = (6 + 1 + 1 + 2 + non_padded_header_len) % alignment;
+    std::size_t const padding = remainder == 0 ? 0 : alignment - remainder;
     if (!std::in_range<std::uint16_t>(non_padded_header_len + padding)) {
         throw std::runtime_error("save_npy: header too large for npy v1.0.");
     }

--- a/src/ddc/save_npy.hpp
+++ b/src/ddc/save_npy.hpp
@@ -86,6 +86,22 @@ struct NpyArrayView
     bool fortran_order;
 };
 
+template <typename T, typename Extents, typename Layout, typename Accessor>
+NpyArrayView to_np_array_view(Kokkos::mdspan<T, Extents, Layout, Accessor> const& mds)
+{
+    std::vector<std::size_t> shape(Extents::rank());
+    for (std::size_t i = 0; i < shape.size(); ++i) {
+        shape[i] = mds.extent(i);
+    }
+
+    return NpyArrayView {
+            .data = mds.data_handle(),
+            .dtype = convert_to_npy_dtype<std::remove_const_t<T>>(),
+            .shape = std::move(shape),
+            .fortran_order = std::is_same_v<Layout, Kokkos::layout_left>,
+    };
+}
+
 void save_npy(std::ostream& os, NpyArrayView const& view);
 
 void save_npy(std::filesystem::path const& filename, NpyArrayView const& view);
@@ -111,19 +127,7 @@ void save_npy(std::ostream& os, Kokkos::mdspan<T, Extents, Layout, Accessor> con
                     || std::is_same_v<Layout, Kokkos::layout_right>,
             "save_npy: only contiguous layouts supported.");
 
-    std::vector<std::size_t> shape(Extents::rank());
-    for (std::size_t i = 0; i < shape.size(); ++i) {
-        shape[i] = mds.extent(i);
-    }
-
-    ddc::detail::save_npy(
-            os,
-            ddc::detail::NpyArrayView {
-                    .data = mds.data_handle(),
-                    .dtype = ddc::detail::convert_to_npy_dtype<std::remove_const_t<T>>(),
-                    .shape = std::move(shape),
-                    .fortran_order = std::is_same_v<Layout, Kokkos::layout_left>,
-            });
+    ddc::detail::save_npy(os, ddc::detail::to_np_array_view(mds));
 }
 
 /**
@@ -145,19 +149,7 @@ void save_npy(
                     || std::is_same_v<Layout, Kokkos::layout_right>,
             "save_npy: only contiguous layouts supported.");
 
-    std::vector<std::size_t> shape(Extents::rank());
-    for (std::size_t i = 0; i < shape.size(); ++i) {
-        shape[i] = mds.extent(i);
-    }
-
-    ddc::detail::save_npy(
-            filename,
-            ddc::detail::NpyArrayView {
-                    .data = mds.data_handle(),
-                    .dtype = ddc::detail::convert_to_npy_dtype<std::remove_const_t<T>>(),
-                    .shape = std::move(shape),
-                    .fortran_order = std::is_same_v<Layout, Kokkos::layout_left>,
-            });
+    ddc::detail::save_npy(filename, ddc::detail::to_np_array_view(mds));
 }
 
 } // namespace ddc::experimental

--- a/src/ddc/save_npy.hpp
+++ b/src/ddc/save_npy.hpp
@@ -110,10 +110,6 @@ void save_npy(std::ostream& os, Kokkos::mdspan<T, Extents, Layout, Accessor> con
             std::is_same_v<Layout, Kokkos::layout_left>
                     || std::is_same_v<Layout, Kokkos::layout_right>,
             "save_npy: only contiguous layouts supported.");
-    static_assert(
-            std::is_same_v<Accessor, Kokkos::default_accessor<T>>
-                    || std::is_same_v<Accessor, Kokkos::default_accessor<T const>>,
-            "save_npy: non-host-accessible accessor. Use create_mirror_view + deep_copy first.");
 
     std::vector<std::size_t> shape(Extents::rank());
     for (std::size_t i = 0; i < Extents::rank(); ++i) {
@@ -148,10 +144,6 @@ void save_npy(
             std::is_same_v<Layout, Kokkos::layout_left>
                     || std::is_same_v<Layout, Kokkos::layout_right>,
             "save_npy: only contiguous layouts supported.");
-    static_assert(
-            std::is_same_v<Accessor, Kokkos::default_accessor<T>>
-                    || std::is_same_v<Accessor, Kokkos::default_accessor<T const>>,
-            "save_npy: non-host-accessible accessor. Use create_mirror_view + deep_copy first.");
 
     std::vector<std::size_t> shape(Extents::rank());
     if constexpr (Extents::rank() > 0) {

--- a/src/ddc/save_npy.hpp
+++ b/src/ddc/save_npy.hpp
@@ -112,7 +112,7 @@ void save_npy(std::ostream& os, Kokkos::mdspan<T, Extents, Layout, Accessor> con
             "save_npy: only contiguous layouts supported.");
 
     std::vector<std::size_t> shape(Extents::rank());
-    for (std::size_t i = 0; i < Extents::rank(); ++i) {
+    for (std::size_t i = 0; i < shape.size(); ++i) {
         shape[i] = mds.extent(i);
     }
 
@@ -146,10 +146,8 @@ void save_npy(
             "save_npy: only contiguous layouts supported.");
 
     std::vector<std::size_t> shape(Extents::rank());
-    if constexpr (Extents::rank() > 0) {
-        for (std::size_t i = 0; i < Extents::rank(); ++i) {
-            shape[i] = mds.extent(i);
-        }
+    for (std::size_t i = 0; i < shape.size(); ++i) {
+        shape[i] = mds.extent(i);
     }
 
     ddc::detail::save_npy(

--- a/src/ddc/save_npy.hpp
+++ b/src/ddc/save_npy.hpp
@@ -53,7 +53,9 @@ NpyDtype convert_to_npy_dtype()
         // std::byte → raw byte buffer, no arithmetic meaning
         kind = NpyKind::other;
     } else if constexpr (
-            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>) {
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>
+            || std::is_same_v<T, Kokkos::complex<float>>
+            || std::is_same_v<T, Kokkos::complex<double>>) {
         // ── Complex ───────────────────────────────────────────────────────
         // NumPy 'c' dtype stores interleaved real+imag, same layout as std::complex
         kind = NpyKind::complex;

--- a/src/ddc/save_npy.hpp
+++ b/src/ddc/save_npy.hpp
@@ -52,9 +52,6 @@ NpyDtype convert_to_npy_dtype()
     } else if constexpr (std::is_same_v<T, std::byte>) {
         // std::byte → raw byte buffer, no arithmetic meaning
         kind = NpyKind::other;
-    } else if constexpr (std::is_same_v<T, char>) {
-        // char is a distinct type; its signedness is implementation-defined
-        kind = std::is_signed_v<char> ? NpyKind::signed_int : NpyKind::unsigned_int;
     } else if constexpr (
             std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>) {
         // ── Complex ───────────────────────────────────────────────────────

--- a/src/ddc/save_npy.hpp
+++ b/src/ddc/save_npy.hpp
@@ -1,0 +1,173 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+#include <filesystem>
+#include <iosfwd>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <Kokkos_Core.hpp>
+
+namespace ddc::detail {
+
+enum class NpyByteOrder : char { little_endian = '<', big_endian = '>', not_applicable = '|' };
+
+NpyByteOrder get_byte_order(std::size_t itemsize) noexcept;
+
+enum class NpyKind : char {
+    boolean = 'b',
+    signed_int = 'i',
+    unsigned_int = 'u',
+    floating_point = 'f',
+    complex = 'c',
+    other = 'V',
+};
+
+struct NpyDtype
+{
+    NpyByteOrder byte_order;
+    NpyKind kind;
+    std::size_t itemsize; // in bytes
+
+    std::string str() const;
+};
+
+template <typename T>
+NpyDtype convert_to_npy_dtype()
+{
+    std::size_t const itemsize = sizeof(T);
+    NpyByteOrder const byte_order = get_byte_order(itemsize);
+    NpyKind kind;
+
+    if constexpr (std::is_same_v<T, bool>) {
+        // ── Single-byte / untyped ─────────────────────────────────────────
+        kind = NpyKind::boolean;
+    } else if constexpr (std::is_same_v<T, std::byte>) {
+        // std::byte → raw byte buffer, no arithmetic meaning
+        kind = NpyKind::other;
+    } else if constexpr (std::is_same_v<T, char>) {
+        // char is a distinct type; its signedness is implementation-defined
+        kind = std::is_signed_v<char> ? NpyKind::signed_int : NpyKind::unsigned_int;
+    } else if constexpr (
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>) {
+        // ── Complex ───────────────────────────────────────────────────────
+        // NumPy 'c' dtype stores interleaved real+imag, same layout as std::complex
+        kind = NpyKind::complex;
+    } else if constexpr (std::is_floating_point_v<T>) {
+        // ── Floating-point ────────────────────────────────────────────────
+        static_assert(
+                !std::is_same_v<T, long double>,
+                "long double is platform-specific (80/96/128-bit); cast to double first.");
+        kind = NpyKind::floating_point;
+    } else if constexpr (std::is_signed_v<T>) {
+        // ── Integers ──────────────────────────────────────────────────────
+        kind = NpyKind::signed_int;
+    } else if constexpr (std::is_unsigned_v<T>) {
+        kind = NpyKind::unsigned_int;
+    } else {
+        static_assert(sizeof(T) == 0, "Unsupported type for NpyDtype::of<T>()");
+    }
+
+    return {.byte_order = byte_order, .kind = kind, .itemsize = itemsize};
+}
+
+struct NpyArrayView
+{
+    void const* data;
+    NpyDtype dtype;
+    std::vector<std::size_t> shape;
+    bool fortran_order;
+};
+
+void save_npy(std::ostream& os, NpyArrayView const& view);
+
+void save_npy(std::filesystem::path const& filename, NpyArrayView const& view);
+
+} // namespace ddc::detail
+
+namespace ddc::experimental {
+
+/**
+ * @brief Save a contiguous mdspan in the NumPy format in a stream.
+ *
+ * Supports Kokkos::layout_left and Kokkos::layout_right layouts with
+ * host-accessible default accessors.
+ *
+ * @param os Output stream receiving the .npy data.
+ * @param mds mdspan to serialize.
+ */
+template <typename T, typename Extents, typename Layout, typename Accessor>
+void save_npy(std::ostream& os, Kokkos::mdspan<T, Extents, Layout, Accessor> const& mds)
+{
+    static_assert(
+            std::is_same_v<Layout, Kokkos::layout_left>
+                    || std::is_same_v<Layout, Kokkos::layout_right>,
+            "save_npy: only contiguous layouts supported.");
+    static_assert(
+            std::is_same_v<Accessor, Kokkos::default_accessor<T>>
+                    || std::is_same_v<Accessor, Kokkos::default_accessor<T const>>,
+            "save_npy: non-host-accessible accessor. Use create_mirror_view + deep_copy first.");
+
+    std::vector<std::size_t> shape(Extents::rank());
+    for (std::size_t i = 0; i < Extents::rank(); ++i) {
+        shape[i] = mds.extent(i);
+    }
+
+    ddc::detail::save_npy(
+            os,
+            ddc::detail::NpyArrayView {
+                    .data = mds.data_handle(),
+                    .dtype = ddc::detail::convert_to_npy_dtype<std::remove_const_t<T>>(),
+                    .shape = std::move(shape),
+                    .fortran_order = std::is_same_v<Layout, Kokkos::layout_left>,
+            });
+}
+
+/**
+ * @brief Save a contiguous mdspan in the NumPy format in a file.
+ *
+ * Supports Kokkos::layout_left and Kokkos::layout_right layouts with
+ * host-accessible default accessors.
+ *
+ * @param filename Path to the output .npy file.
+ * @param mds mdspan to serialize.
+ */
+template <typename T, typename Extents, typename Layout, typename Accessor>
+void save_npy(
+        std::filesystem::path const& filename,
+        Kokkos::mdspan<T, Extents, Layout, Accessor> const& mds)
+{
+    static_assert(
+            std::is_same_v<Layout, Kokkos::layout_left>
+                    || std::is_same_v<Layout, Kokkos::layout_right>,
+            "save_npy: only contiguous layouts supported.");
+    static_assert(
+            std::is_same_v<Accessor, Kokkos::default_accessor<T>>
+                    || std::is_same_v<Accessor, Kokkos::default_accessor<T const>>,
+            "save_npy: non-host-accessible accessor. Use create_mirror_view + deep_copy first.");
+
+    std::vector<std::size_t> shape(Extents::rank());
+    if constexpr (Extents::rank() > 0) {
+        for (std::size_t i = 0; i < Extents::rank(); ++i) {
+            shape[i] = mds.extent(i);
+        }
+    }
+
+    ddc::detail::save_npy(
+            filename,
+            ddc::detail::NpyArrayView {
+                    .data = mds.data_handle(),
+                    .dtype = ddc::detail::convert_to_npy_dtype<std::remove_const_t<T>>(),
+                    .shape = std::move(shape),
+                    .fortran_order = std::is_same_v<Layout, Kokkos::layout_left>,
+            });
+}
+
+} // namespace ddc::experimental

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,8 @@ include(GoogleTest)
 
 add_subdirectory(discrete_space)
 
+add_subdirectory(save_npy)
+
 add_library(ddc_gtest_main)
 target_compile_features(ddc_gtest_main PRIVATE cxx_std_20)
 target_link_libraries(ddc_gtest_main PRIVATE DDC::core GTest::gtest)
@@ -43,6 +45,7 @@ add_executable(
     reducer.cpp
     relocatable_device_code.cpp
     relocatable_device_code_initialization.cpp
+    save_npy.cpp
     sparse_discrete_domain.cpp
     strided_discrete_domain.cpp
     tagged_vector.cpp

--- a/tests/save_npy.cpp
+++ b/tests/save_npy.cpp
@@ -1,0 +1,24 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+
+TEST(SaveNpy, LargeHeader)
+{
+    ddc::detail::NpyArrayView const view {
+            .data = nullptr,
+            .dtype = ddc::detail::convert_to_npy_dtype<char>(),
+            .shape = std::vector<std::size_t>(25'000, 0),
+            .fortran_order = true,
+    };
+    EXPECT_THROW(ddc::detail::save_npy("test.npy", view), std::runtime_error);
+}

--- a/tests/save_npy/CMakeLists.txt
+++ b/tests/save_npy/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
+add_executable(generate_npy_fixtures generate_npy_fixtures.cpp)
+target_link_libraries(generate_npy_fixtures PRIVATE DDC::core Kokkos::kokkos)
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import numpy, pytest"
+    RESULT_VARIABLE _py_deps_ok
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+if(NOT _py_deps_ok EQUAL 0)
+    message(WARNING "numpy or pytest not found — skipping npy validation tests")
+else()
+    add_test(NAME NpyGenerateFixtures COMMAND generate_npy_fixtures)
+
+    add_test(
+        NAME NpyValidatePython
+        COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test_npy_fixtures.py
+    )
+
+    # Guarantee ordering: generate before validate
+    set_tests_properties(NpyValidatePython PROPERTIES DEPENDS NpyGenerateFixtures)
+endif()

--- a/tests/save_npy/generate_npy_fixtures.cpp
+++ b/tests/save_npy/generate_npy_fixtures.cpp
@@ -1,0 +1,93 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <filesystem>
+#include <type_traits>
+
+#include <ddc/ddc.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace {
+
+std::array constexpr ns {2, 3, 4};
+int constexpr n = ns[0] * ns[1] * ns[2];
+
+template <typename T>
+constexpr T make_value()
+{
+    std::complex<double> const base_value(2.3, 0.4);
+    if constexpr (
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>) {
+        return T(base_value);
+    } else if constexpr (std::is_floating_point_v<T>) {
+        return T(std::real(base_value));
+    } else {
+        return T(std::llround(std::real(base_value)));
+    }
+}
+
+template <typename T>
+void save_array_0d(std::filesystem::path const& path, T value)
+{
+    Kokkos::View<T, Kokkos::HostSpace> const alloc("");
+    Kokkos::deep_copy(alloc, value);
+    Kokkos::mdspan const view(alloc.data());
+
+    ddc::experimental::save_npy(path, view);
+}
+
+template <typename T>
+void save_array_1d(std::filesystem::path const& path, T value)
+{
+    Kokkos::View<T*, Kokkos::HostSpace> const alloc("", n);
+    Kokkos::deep_copy(alloc, value);
+    Kokkos::mdspan const view(alloc.data(), n);
+
+    ddc::experimental::save_npy(path, view);
+}
+
+template <typename T>
+void save_array_3d(std::filesystem::path const& path, T value)
+{
+    Kokkos::View<T*, Kokkos::HostSpace> const alloc("", n);
+    Kokkos::deep_copy(alloc, value);
+    Kokkos::mdspan const view(alloc.data(), ns);
+
+    ddc::experimental::save_npy(path, view);
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    Kokkos::ScopeGuard const kokkos(argc, argv);
+    ddc::ScopeGuard const ddc(argc, argv);
+
+    save_array_0d("./float_0d.npy", make_value<float>());
+
+    save_array_1d("./double_1d.npy", make_value<double>());
+
+    save_array_3d("./int8_3d.npy", make_value<std::int8_t>());
+    save_array_3d("./int16_3d.npy", make_value<std::int16_t>());
+    save_array_3d("./int32_3d.npy", make_value<std::int32_t>());
+    save_array_3d("./int64_3d.npy", make_value<std::int64_t>());
+
+    save_array_3d("./uint8_3d.npy", make_value<std::uint8_t>());
+    save_array_3d("./uint16_3d.npy", make_value<std::uint16_t>());
+    save_array_3d("./uint32_3d.npy", make_value<std::uint32_t>());
+    save_array_3d("./uint64_3d.npy", make_value<std::uint64_t>());
+
+    save_array_3d("./float_3d.npy", make_value<float>());
+    save_array_3d("./double_3d.npy", make_value<double>());
+
+    save_array_3d("./complex_float_3d.npy", make_value<std::complex<float>>());
+    save_array_3d("./complex_double_3d.npy", make_value<std::complex<double>>());
+
+    return 0;
+}

--- a/tests/save_npy/generate_npy_fixtures.cpp
+++ b/tests/save_npy/generate_npy_fixtures.cpp
@@ -21,14 +21,17 @@ int constexpr n = ns[0] * ns[1] * ns[2];
 template <typename T>
 constexpr T make_value()
 {
-    std::complex<double> const base_value(2.3, 0.4);
+    double const real = 2.3;
+    double const imag = 0.4;
     if constexpr (
-            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>) {
-        return T(base_value);
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>
+            || std::is_same_v<T, Kokkos::complex<float>>
+            || std::is_same_v<T, Kokkos::complex<double>>) {
+        return T(real, imag);
     } else if constexpr (std::is_floating_point_v<T>) {
-        return T(std::real(base_value));
+        return T(real);
     } else {
-        return T(std::llround(std::real(base_value)));
+        return T(std::llround(real));
     }
 }
 
@@ -86,8 +89,10 @@ int main(int argc, char** argv)
     save_array_3d("./float_3d.npy", make_value<float>());
     save_array_3d("./double_3d.npy", make_value<double>());
 
-    save_array_3d("./complex_float_3d.npy", make_value<std::complex<float>>());
-    save_array_3d("./complex_double_3d.npy", make_value<std::complex<double>>());
+    save_array_3d("./std_complex_float_3d.npy", make_value<std::complex<float>>());
+    save_array_3d("./std_complex_double_3d.npy", make_value<std::complex<double>>());
+    save_array_3d("./kokkos_complex_float_3d.npy", make_value<Kokkos::complex<float>>());
+    save_array_3d("./kokkos_complex_double_3d.npy", make_value<Kokkos::complex<double>>());
 
     return 0;
 }

--- a/tests/save_npy/test_npy_fixtures.py
+++ b/tests/save_npy/test_npy_fixtures.py
@@ -1,0 +1,65 @@
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for verifying saved NumPy .npy fixtures across dtypes and shapes."""
+
+import numpy as np
+
+
+def gen_value(dtype):
+    """Generate a scalar value appropriate for the given NumPy dtype."""
+    base_value = np.complex128(2.3 + 0.4j)
+    if np.issubdtype(dtype, np.complexfloating):
+        return dtype(base_value)
+    if np.issubdtype(dtype, np.floating):
+        return dtype(np.real(base_value))
+    return dtype(np.round(np.real(base_value)))
+
+
+def gen_array_0d(dtype):
+    """Generate a 0D NumPy array filled with a dtype-specific value."""
+    return np.full(shape=(), fill_value=gen_value(dtype), order="C")
+
+
+def gen_array_1d(dtype):
+    """Generate a 1D NumPy array of length 24 filled with a dtype-specific value."""
+    return np.full(shape=(2 * 3 * 4), fill_value=gen_value(dtype), order="C")
+
+
+def gen_array_3d(dtype):
+    """Generate a 3D NumPy array (2x3x4) filled with a dtype-specific value."""
+    return np.full(shape=(2, 3, 4), fill_value=gen_value(dtype), order="C")
+
+
+def test_0d():
+    """Test loading and equality of a 0D float32 array."""
+    np.testing.assert_array_equal(np.load("float_0d.npy"), gen_array_0d(np.float32), strict=True)
+
+
+def test_1d():
+    """Test loading and equality of a 1D float64 array."""
+    np.testing.assert_array_equal(np.load("double_1d.npy"), gen_array_1d(np.float64), strict=True)
+
+
+def test_3d():
+    """Test loading and equality of multiple 3D arrays across dtypes."""
+    np.testing.assert_array_equal(np.load("int8_3d.npy"), gen_array_3d(np.int8), strict=True)
+    np.testing.assert_array_equal(np.load("int16_3d.npy"), gen_array_3d(np.int16), strict=True)
+    np.testing.assert_array_equal(np.load("int32_3d.npy"), gen_array_3d(np.int32), strict=True)
+    np.testing.assert_array_equal(np.load("int64_3d.npy"), gen_array_3d(np.int64), strict=True)
+
+    np.testing.assert_array_equal(np.load("uint8_3d.npy"), gen_array_3d(np.uint8), strict=True)
+    np.testing.assert_array_equal(np.load("uint16_3d.npy"), gen_array_3d(np.uint16), strict=True)
+    np.testing.assert_array_equal(np.load("uint32_3d.npy"), gen_array_3d(np.uint32), strict=True)
+    np.testing.assert_array_equal(np.load("uint64_3d.npy"), gen_array_3d(np.uint64), strict=True)
+
+    np.testing.assert_array_equal(np.load("float_3d.npy"), gen_array_3d(np.float32), strict=True)
+    np.testing.assert_array_equal(np.load("double_3d.npy"), gen_array_3d(np.float64), strict=True)
+
+    np.testing.assert_array_equal(
+        np.load("complex_float_3d.npy"), gen_array_3d(np.complex64), strict=True
+    )
+    np.testing.assert_array_equal(
+        np.load("complex_double_3d.npy"), gen_array_3d(np.complex128), strict=True
+    )

--- a/tests/save_npy/test_npy_fixtures.py
+++ b/tests/save_npy/test_npy_fixtures.py
@@ -58,8 +58,14 @@ def test_3d():
     np.testing.assert_array_equal(np.load("double_3d.npy"), gen_array_3d(np.float64), strict=True)
 
     np.testing.assert_array_equal(
-        np.load("complex_float_3d.npy"), gen_array_3d(np.complex64), strict=True
+        np.load("std_complex_float_3d.npy"), gen_array_3d(np.complex64), strict=True
     )
     np.testing.assert_array_equal(
-        np.load("complex_double_3d.npy"), gen_array_3d(np.complex128), strict=True
+        np.load("std_complex_double_3d.npy"), gen_array_3d(np.complex128), strict=True
+    )
+    np.testing.assert_array_equal(
+        np.load("kokkos_complex_float_3d.npy"), gen_array_3d(np.complex64), strict=True
+    )
+    np.testing.assert_array_equal(
+        np.load("kokkos_complex_double_3d.npy"), gen_array_3d(np.complex128), strict=True
     )


### PR DESCRIPTION
Add the possibility to save a `Kokkos::mdspan` in a Numpy file format (version 1.0). It is only implemented for layouts left and right, and for some scalar types.

It should be reviewed with this compatibility table in mind https://numpy.org/doc/stable/user/basics.types.html#relationship-between-numpy-data-types-and-c-data-types. Note that I find surprising that fixed width numpy types correspond to non-fixed width types in C.

We could also check  that floating point types are IEEE754 compliant with https://en.cppreference.com/cpp/types/numeric_limits/is_iec559.