### PR TITLE
Correct structured bindings link in first_steps.md

### DIFF
--- a/docs/first_steps.md
+++ b/docs/first_steps.md
@@ -72,7 +72,7 @@ function.
 Depending on the way the function is called, its return type can differ.
 Here we use it with an inner call to `init_ghosted` and receive four 1D domains as a result.
 Their type is not specified because we use C++
-[structured bindings](https://en.cppreference.com/w/cpp/language/structured_binding.html), but they are
+[structured bindings](https://en.cppreference.com/cpp/language/structured_binding), but they are
 all of the same type: `DiscreteDomain<DDimX>` that represents a set of contiguous points in the
 discretization of `X`.
 


### PR DESCRIPTION
Fix link formatting for structured bindings in documentation.