### PR TITLE
Apply IWYU advices

### DIFF
--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -54,7 +54,9 @@ struct DDimX : GrevillePoints<IsNonUniform, DegreeX>::interpolation_discrete_dim
 {
 };
 
-struct Y;
+struct Y
+{
+};
 
 struct DDimY : ddc::UniformPointSampling<Y>
 {

--- a/examples/characteristics_advection.cpp
+++ b/examples/characteristics_advection.cpp
@@ -54,7 +54,9 @@ struct DDimX : GrevillePoints::interpolation_discrete_dimension_type
 
 //! [Y-space]
 // Our second continuous dimension
-struct Y;
+struct Y
+{
+};
 // Its uniform discretization
 struct DDimY : ddc::UniformPointSampling<Y>
 {
@@ -63,7 +65,9 @@ struct DDimY : ddc::UniformPointSampling<Y>
 
 //! [time-space]
 // Our simulated time dimension
-struct T;
+struct T
+{
+};
 // Its uniform discretization
 struct DDimT : ddc::UniformPointSampling<T>
 {

--- a/examples/heat_equation.cpp
+++ b/examples/heat_equation.cpp
@@ -19,7 +19,9 @@
 
 //! [X-dimension]
 /// Our first continuous dimension
-struct X;
+struct X
+{
+};
 //! [X-dimension]
 
 //! [X-discretization]
@@ -31,7 +33,9 @@ struct DDimX : ddc::UniformPointSampling<X>
 
 //! [Y-space]
 // Our second continuous dimension
-struct Y;
+struct Y
+{
+};
 // Its uniform discretization
 struct DDimY : ddc::UniformPointSampling<Y>
 {
@@ -40,7 +44,9 @@ struct DDimY : ddc::UniformPointSampling<Y>
 
 //! [time-space]
 // Our simulated time dimension
-struct T;
+struct T
+{
+};
 // Its uniform discretization
 struct DDimT : ddc::UniformPointSampling<T>
 {

--- a/examples/heat_equation_spectral.cpp
+++ b/examples/heat_equation_spectral.cpp
@@ -15,7 +15,9 @@
 #include <Kokkos_Core.hpp>
 
 /// Our first continuous dimension
-struct X;
+struct X
+{
+};
 
 /// A uniform discretization of X
 struct DDimX : ddc::UniformPointSampling<X>
@@ -27,7 +29,9 @@ struct DDimFx : ddc::PeriodicSampling<ddc::Fourier<X>>
 };
 
 // Our second continuous dimension
-struct Y;
+struct Y
+{
+};
 // Its uniform discretization
 struct DDimY : ddc::UniformPointSampling<Y>
 {
@@ -38,7 +42,9 @@ struct DDimFy : ddc::PeriodicSampling<ddc::Fourier<Y>>
 };
 
 // Our simulated time dimension
-struct T;
+struct T
+{
+};
 // Its uniform discretization
 struct DDimT : ddc::UniformPointSampling<T>
 {

--- a/examples/non_uniform_heat_equation.cpp
+++ b/examples/non_uniform_heat_equation.cpp
@@ -90,7 +90,9 @@ std::vector<double> periodic_extrapolation_right(int gw, std::vector<double> con
 }
 
 //! [X-dimension]
-struct X;
+struct X
+{
+};
 //! [X-dimension]
 
 //! [X-discretization]
@@ -100,14 +102,18 @@ struct DDimX : ddc::NonUniformPointSampling<X>
 //! [X-discretization]
 
 //! [Y-space]
-struct Y;
+struct Y
+{
+};
 struct DDimY : ddc::NonUniformPointSampling<Y>
 {
 };
 //! [Y-space]
 
 //! [time-space]
-struct T;
+struct T
+{
+};
 struct DDimT : ddc::UniformPointSampling<T>
 {
 };

--- a/examples/uniform_heat_equation.cpp
+++ b/examples/uniform_heat_equation.cpp
@@ -17,7 +17,9 @@
 //! [includes]
 
 //! [X-dimension]
-struct X;
+struct X
+{
+};
 //! [X-dimension]
 
 //! [X-discretization]
@@ -27,14 +29,18 @@ struct DDimX : ddc::UniformPointSampling<X>
 //! [X-discretization]
 
 //! [Y-space]
-struct Y;
+struct Y
+{
+};
 struct DDimY : ddc::UniformPointSampling<Y>
 {
 };
 //! [Y-space]
 
 //! [time-space]
-struct T;
+struct T
+{
+};
 struct DDimT : ddc::UniformPointSampling<T>
 {
 };

--- a/src/ddc/chunk_span.hpp
+++ b/src/ddc/chunk_span.hpp
@@ -126,10 +126,12 @@ protected:
     }
 
     template <class TypeSeq>
-    struct slicer;
+    struct Slicer
+    {
+    };
 
     template <class... DDims>
-    struct slicer<detail::TypeSeq<DDims...>>
+    struct Slicer<detail::TypeSeq<DDims...>>
     {
         template <class... ODDims>
         KOKKOS_FUNCTION constexpr auto operator()(
@@ -267,9 +269,9 @@ public:
             DiscreteElement<QueryDDims...> const& slice_spec) const
     {
         using detail::TypeSeq;
-        using QueryDDom = detail::RebindDomain<SupportType, TypeSeq<QueryDDims...>>::type;
+        using QueryDDom = detail::Rebind<SupportType, TypeSeq<QueryDDims...>>::type;
         KOKKOS_ASSERT(QueryDDom(this->m_domain).contains(slice_spec))
-        slicer<to_type_seq_t<SupportType>> const slicer;
+        Slicer<to_type_seq_t<SupportType>> const slicer;
         auto subview = slicer(
                 this->allocation_mdspan(),
                 QueryDDom(this->m_domain).distance_from_front(slice_spec));
@@ -277,7 +279,7 @@ public:
         using extents_type = decltype(subview)::extents_type;
         using OutTypeSeqDDims
                 = type_seq_remove_t<to_type_seq_t<SupportType>, TypeSeq<QueryDDims...>>;
-        using OutDDom = detail::RebindDomain<SupportType, OutTypeSeqDDims>::type;
+        using OutDDom = detail::Rebind<SupportType, OutTypeSeqDDims>::type;
         if constexpr (
                 std::is_same_v<layout_type, Kokkos::Experimental::layout_left_padded<>>
                 || std::is_same_v<layout_type, Kokkos::Experimental::layout_right_padded<>>) {
@@ -308,7 +310,7 @@ public:
                 odomain.empty()
                 || (DiscreteDomain<QueryDDims...>(this->m_domain).contains(odomain.front())
                     && DiscreteDomain<QueryDDims...>(this->m_domain).contains(odomain.back())))
-        slicer<to_type_seq_t<SupportType>> const slicer;
+        Slicer<to_type_seq_t<SupportType>> const slicer;
         auto subview = slicer(this->allocation_mdspan(), odomain, this->m_domain);
         using layout_type = decltype(subview)::layout_type;
         using extents_type = decltype(subview)::extents_type;

--- a/src/ddc/ddc.hpp
+++ b/src/ddc/ddc.hpp
@@ -43,6 +43,7 @@ namespace ddc {
 #include "detail/type_seq.hpp"
 #include "detail/utils.hpp"
 
+#include "ddc_to_kokkos_execution_policy.hpp"
 #include "real_type.hpp"
 #include "scope_guard.hpp"
 

--- a/src/ddc/detail/type_seq.hpp
+++ b/src/ddc/detail/type_seq.hpp
@@ -14,14 +14,20 @@ namespace ddc {
 
 namespace detail {
 
-template <class...>
-struct TypeSeq;
+template <class... Tags>
+struct TypeSeq
+{
+};
 
-template <class>
-struct SingleType;
+template <class Tag>
+struct SingleType
+{
+};
 
-template <class...>
-struct TypeSeqRank;
+template <class QueryTagSeq, class TagSeq>
+struct TypeSeqRank
+{
+};
 
 template <class QueryTag>
 struct TypeSeqRank<SingleType<QueryTag>, TypeSeq<>>
@@ -53,7 +59,9 @@ struct TypeSeqRank<TypeSeq<QueryTags...>, TypeSeq<Tags...>>
 };
 
 template <std::size_t I, class TagSeq>
-struct TypeSeqElement;
+struct TypeSeqElement
+{
+};
 
 template <std::size_t I, class... Tags>
 struct TypeSeqElement<I, TypeSeq<Tags...>>
@@ -66,7 +74,9 @@ struct TypeSeqElement<I, TypeSeq<Tags...>>
 /// Remark 2: It is similar to the set difference in the set theory (R = A\\B).
 /// Example: A = [a, b, c], B = [z, c, y], R = [a, b]
 template <class TagSeqA, class TagSeqB, class TagSeqR>
-struct TypeSeqRemove;
+struct TypeSeqRemove
+{
+};
 
 template <class... TagsB, class... TagsR>
 struct TypeSeqRemove<TypeSeq<>, TypeSeq<TagsB...>, TypeSeq<TagsR...>>
@@ -88,7 +98,9 @@ struct TypeSeqRemove<TypeSeq<HeadTagsA, TailTagsA...>, TypeSeq<TagsB...>, TypeSe
 /// Remark 2: It is similar to the set union in the set theory (R = AUB).
 /// Example: A = [a, b, c], B = [z, c, y], R = [a, b, c, z, y]
 template <class TagSeqA, class TagSeqB, class TagSeqR>
-struct TypeSeqMerge;
+struct TypeSeqMerge
+{
+};
 
 template <class... TagsA, class... TagsR>
 struct TypeSeqMerge<TypeSeq<TagsA...>, TypeSeq<>, TypeSeq<TagsR...>>
@@ -108,7 +120,9 @@ struct TypeSeqMerge<TypeSeq<TagsA...>, TypeSeq<HeadTagsB, TailTagsB...>, TypeSeq
 /// `type` contains all elements in A then all elements in B.
 /// Example: A = [a, b, c], B = [z, c, y], returned type [a, b, c, z, c, y]
 template <class TagSeqA, class TagSeqB>
-struct TypeSeqCat;
+struct TypeSeqCat
+{
+};
 
 template <class... TagsA, class... TagsB>
 struct TypeSeqCat<TypeSeq<TagsA...>, TypeSeq<TagsB...>>
@@ -119,7 +133,9 @@ struct TypeSeqCat<TypeSeq<TagsA...>, TypeSeq<TagsB...>>
 /// A is replaced by element of C at same position than the first element of B equal to A.
 /// Remark : It may not be useful in its own, it is an helper for TypeSeqReplace
 template <class TagA, class TagSeqB, class TagSeqC>
-struct TypeSeqReplaceSingle;
+struct TypeSeqReplaceSingle
+{
+};
 
 template <class TagA>
 struct TypeSeqReplaceSingle<TagA, TypeSeq<>, TypeSeq<>>
@@ -142,7 +158,9 @@ struct TypeSeqReplaceSingle<
 /// R contains all elements of A except those of B which are replaced by those of C.
 /// Remark : This operation preserves the orders.
 template <class TagSeqA, class TagSeqB, class TagSeqC, class TagSeqR>
-struct TypeSeqReplace;
+struct TypeSeqReplace
+{
+};
 
 template <class... TagsB, class... TagsC, class... TagsR>
 struct TypeSeqReplace<TypeSeq<>, TypeSeq<TagsB...>, TypeSeq<TagsC...>, TypeSeq<TagsR...>>
@@ -169,7 +187,14 @@ struct TypeSeqReplace<
 };
 
 template <class T>
-struct ToTypeSeq;
+struct ToTypeSeq
+{
+};
+
+template <class T, class TagSeq>
+struct Rebind
+{
+};
 
 } // namespace detail
 

--- a/src/ddc/discrete_domain.hpp
+++ b/src/ddc/discrete_domain.hpp
@@ -54,11 +54,8 @@ struct ToTypeSeq<DiscreteDomain<Tags...>>
     using type = TypeSeq<Tags...>;
 };
 
-template <class T, class U>
-struct RebindDomain;
-
 template <class... DDims, class... ODDims>
-struct RebindDomain<DiscreteDomain<DDims...>, detail::TypeSeq<ODDims...>>
+struct Rebind<DiscreteDomain<DDims...>, detail::TypeSeq<ODDims...>>
 {
     using type = DiscreteDomain<ODDims...>;
 };
@@ -459,7 +456,9 @@ KOKKOS_FUNCTION constexpr DiscreteDomain<QueryDDims...> select(
 namespace detail {
 
 template <class T>
-struct ConvertTypeSeqToDiscreteDomain;
+struct ConvertTypeSeqToDiscreteDomain
+{
+};
 
 template <class... DDims>
 struct ConvertTypeSeqToDiscreteDomain<detail::TypeSeq<DDims...>>
@@ -471,32 +470,6 @@ template <class T>
 using convert_type_seq_to_discrete_domain_t = ConvertTypeSeqToDiscreteDomain<T>::type;
 
 } // namespace detail
-
-// Computes the cartesian product of DiscreteDomain types
-// Example usage : "using DDom = cartesian_prod_t<DDom1,DDom2,DDom3>;"
-template <typename... DDoms>
-struct cartesian_prod;
-
-template <typename... DDims1, typename... DDims2, typename... DDomsTail>
-struct cartesian_prod<DiscreteDomain<DDims1...>, DiscreteDomain<DDims2...>, DDomsTail...>
-{
-    using type = cartesian_prod<DiscreteDomain<DDims1..., DDims2...>, DDomsTail...>::type;
-};
-
-template <typename... DDims>
-struct cartesian_prod<DiscreteDomain<DDims...>>
-{
-    using type = DiscreteDomain<DDims...>;
-};
-
-template <>
-struct cartesian_prod<>
-{
-    using type = ddc::DiscreteDomain<>;
-};
-
-template <typename... DDoms>
-using cartesian_prod_t = cartesian_prod<DDoms...>::type;
 
 // Computes the subtraction DDom_a - DDom_b in the sense of linear spaces(retained dimensions are those in DDom_a which are not in DDom_b)
 template <class... DDimsA, class... DDimsB>
@@ -573,7 +546,7 @@ KOKKOS_FUNCTION constexpr auto replace_dim_of(
 template <typename DDom, typename DDim1, typename DDim2>
 using replace_dim_of_t = decltype(replace_dim_of<DDim1, DDim2>(
         std::declval<DDom>(),
-        std::declval<typename detail::RebindDomain<DDom, detail::TypeSeq<DDim2>>::type>()));
+        std::declval<typename detail::Rebind<DDom, detail::TypeSeq<DDim2>>::type>()));
 
 
 template <class... QueryDDims, class... DDims>

--- a/src/ddc/discrete_space.cpp
+++ b/src/ddc/discrete_space.cpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <utility>
 
 #include <Kokkos_Macros.hpp>
 

--- a/src/ddc/kernels/fft.hpp
+++ b/src/ddc/kernels/fft.hpp
@@ -21,7 +21,9 @@ namespace ddc {
  * @tparam The tag representing the original dimension.
  */
 template <typename Dim>
-struct Fourier;
+struct Fourier
+{
+};
 
 /**
  * @brief A named argument to choose the direction of the FFT.

--- a/src/ddc/kernels/splines/view.hpp
+++ b/src/ddc/kernels/splines/view.hpp
@@ -13,7 +13,9 @@
 namespace ddc::detail {
 
 template <std::size_t N, class ElementType, bool CONTIGUOUS = true>
-struct ViewNDMaker;
+struct ViewNDMaker
+{
+};
 
 template <std::size_t N, class ElementType>
 struct ViewNDMaker<N, ElementType, true>

--- a/src/ddc/parallel_for_each.hpp
+++ b/src/ddc/parallel_for_each.hpp
@@ -18,7 +18,9 @@ namespace ddc {
 namespace detail {
 
 template <class F, class Support, class IndexSequence>
-class ForEachKokkosLambdaAdapter;
+class ForEachKokkosLambdaAdapter
+{
+};
 
 template <class F, class Support, std::size_t... Idx>
 class ForEachKokkosLambdaAdapter<F, Support, std::index_sequence<Idx...>>

--- a/src/ddc/parallel_transform_reduce.hpp
+++ b/src/ddc/parallel_transform_reduce.hpp
@@ -20,74 +20,78 @@ namespace ddc {
 namespace detail {
 
 template <class Reducer>
-struct ddc_to_kokkos_reducer;
+struct DdcToKokkosReducer
+{
+};
 
 template <class T>
-struct ddc_to_kokkos_reducer<reducer::sum<T>>
+struct DdcToKokkosReducer<reducer::sum<T>>
 {
     using type = Kokkos::Sum<T>;
 };
 
 template <class T>
-struct ddc_to_kokkos_reducer<reducer::prod<T>>
+struct DdcToKokkosReducer<reducer::prod<T>>
 {
     using type = Kokkos::Prod<T>;
 };
 
 template <class T>
-struct ddc_to_kokkos_reducer<reducer::land<T>>
+struct DdcToKokkosReducer<reducer::land<T>>
 {
     using type = Kokkos::LAnd<T>;
 };
 
 template <class T>
-struct ddc_to_kokkos_reducer<reducer::lor<T>>
+struct DdcToKokkosReducer<reducer::lor<T>>
 {
     using type = Kokkos::LOr<T>;
 };
 
 template <class T>
-struct ddc_to_kokkos_reducer<reducer::band<T>>
+struct DdcToKokkosReducer<reducer::band<T>>
 {
     using type = Kokkos::BAnd<T>;
 };
 
 template <class T>
-struct ddc_to_kokkos_reducer<reducer::bor<T>>
+struct DdcToKokkosReducer<reducer::bor<T>>
 {
     using type = Kokkos::BOr<T>;
 };
 
 template <class T>
-struct ddc_to_kokkos_reducer<reducer::bxor<T>>
+struct DdcToKokkosReducer<reducer::bxor<T>>
 {
     static_assert(std::is_same_v<T, T>, "This reducer is not yet implemented");
 };
 
 template <class T>
-struct ddc_to_kokkos_reducer<reducer::min<T>>
+struct DdcToKokkosReducer<reducer::min<T>>
 {
     using type = Kokkos::Min<T>;
 };
 
 template <class T>
-struct ddc_to_kokkos_reducer<reducer::max<T>>
+struct DdcToKokkosReducer<reducer::max<T>>
 {
     using type = Kokkos::Max<T>;
 };
 
 template <class T>
-struct ddc_to_kokkos_reducer<reducer::minmax<T>>
+struct DdcToKokkosReducer<reducer::minmax<T>>
 {
     using type = Kokkos::MinMax<T>;
 };
 
 /// Alias template to transform a DDC reducer type to a Kokkos reducer type
 template <class Reducer>
-using ddc_to_kokkos_reducer_t = ddc_to_kokkos_reducer<Reducer>::type;
+using ddc_to_kokkos_reducer_t = DdcToKokkosReducer<Reducer>::type;
 
 template <class Reducer, class Functor, class Support, class IndexSequence>
-class TransformReducerKokkosLambdaAdapter;
+class TransformReducerKokkosLambdaAdapter
+{
+};
 
 template <class Reducer, class Functor, class Support, std::size_t... Idx>
 class TransformReducerKokkosLambdaAdapter<Reducer, Functor, Support, std::index_sequence<Idx...>>

--- a/src/ddc/print.hpp
+++ b/src/ddc/print.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdlib>
+#include <limits>
 #include <mutex>
 #include <ostream>
 #include <sstream>

--- a/src/ddc/sparse_discrete_domain.hpp
+++ b/src/ddc/sparse_discrete_domain.hpp
@@ -21,9 +21,6 @@
 
 namespace ddc {
 
-template <class DDim>
-struct SparseDiscreteDomainIterator;
-
 template <class... DDims>
 class SparseDiscreteDomain;
 
@@ -55,11 +52,8 @@ struct ToTypeSeq<SparseDiscreteDomain<Tags...>>
     using type = TypeSeq<Tags...>;
 };
 
-template <class T, class U>
-struct RebindDomain;
-
 template <class... DDims, class... ODDims>
-struct RebindDomain<SparseDiscreteDomain<DDims...>, detail::TypeSeq<ODDims...>>
+struct Rebind<SparseDiscreteDomain<DDims...>, detail::TypeSeq<ODDims...>>
 {
     using type = SparseDiscreteDomain<ODDims...>;
 };
@@ -507,7 +501,9 @@ KOKKOS_FUNCTION constexpr SparseDiscreteDomain<QueryDDims...> select(
 namespace detail {
 
 template <class T>
-struct ConvertTypeSeqToSparseDiscreteDomain;
+struct ConvertTypeSeqToSparseDiscreteDomain
+{
+};
 
 template <class... DDims>
 struct ConvertTypeSeqToSparseDiscreteDomain<detail::TypeSeq<DDims...>>

--- a/src/ddc/strided_discrete_domain.hpp
+++ b/src/ddc/strided_discrete_domain.hpp
@@ -53,11 +53,8 @@ struct ToTypeSeq<StridedDiscreteDomain<Tags...>>
     using type = TypeSeq<Tags...>;
 };
 
-template <class T, class U>
-struct RebindDomain;
-
 template <class... DDims, class... ODDims>
-struct RebindDomain<StridedDiscreteDomain<DDims...>, detail::TypeSeq<ODDims...>>
+struct Rebind<StridedDiscreteDomain<DDims...>, detail::TypeSeq<ODDims...>>
 {
     using type = StridedDiscreteDomain<ODDims...>;
 };
@@ -472,7 +469,9 @@ KOKKOS_FUNCTION constexpr StridedDiscreteDomain<QueryDDims...> select(
 namespace detail {
 
 template <class T>
-struct ConvertTypeSeqToStridedDiscreteDomain;
+struct ConvertTypeSeqToStridedDiscreteDomain
+{
+};
 
 template <class... DDims>
 struct ConvertTypeSeqToStridedDiscreteDomain<detail::TypeSeq<DDims...>>

--- a/tests/discrete_domain.cpp
+++ b/tests/discrete_domain.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <type_traits>
-
 #include <ddc/ddc.hpp>
 
 #include <gtest/gtest.h>
@@ -319,14 +317,6 @@ TEST(DiscreteDomainTest, Transpose3DConstructor)
     EXPECT_EQ(DElemX(dom_x_y_z.back()), DElemX(dom_z_y_x.back()));
     EXPECT_EQ(DElemY(dom_x_y_z.back()), DElemY(dom_z_y_x.back()));
     EXPECT_EQ(DElemZ(dom_x_y_z.back()), DElemZ(dom_z_y_x.back()));
-}
-
-TEST(DiscreteDomainTest, CartesianProduct)
-{
-    EXPECT_TRUE((std::is_same_v<ddc::cartesian_prod_t<>, ddc::DiscreteDomain<>>));
-    EXPECT_TRUE((std::is_same_v<ddc::cartesian_prod_t<DDomX>, DDomX>));
-    EXPECT_TRUE((std::is_same_v<ddc::cartesian_prod_t<DDomX, DDomY, DDomZ>, DDomXYZ>));
-    EXPECT_TRUE((std::is_same_v<ddc::cartesian_prod_t<DDomZY, DDomX>, DDomZYX>));
 }
 
 TEST(DiscreteDomainTest, Select)

--- a/tests/discrete_space.cpp
+++ b/tests/discrete_space.cpp
@@ -13,7 +13,9 @@
 
 inline namespace anonymous_namespace_workaround_discrete_space_cpp {
 
-struct DimX;
+struct DimX
+{
+};
 struct DDimX : ddc::UniformPointSampling<DimX>
 {
 };

--- a/tests/discrete_space/discrete_space.cpp
+++ b/tests/discrete_space/discrete_space.cpp
@@ -8,7 +8,9 @@
 
 #include "discrete_space.hpp"
 
-struct DimX;
+struct DimX
+{
+};
 struct DDimX : ddc::UniformPointSampling<DimX>
 {
 };

--- a/tests/fft/fft.cpp
+++ b/tests/fft/fft.cpp
@@ -241,9 +241,15 @@ void test_fft_norm(ddc::FFT_Normalization const norm)
     EXPECT_NEAR(FFf(FFf.domain().back()), FFf_expected, epsilon);
 }
 
-struct RDimX;
-struct RDimY;
-struct RDimZ;
+struct RDimX
+{
+};
+struct RDimY
+{
+};
+struct RDimZ
+{
+};
 
 } // namespace anonymous_namespace_workaround_fft_cpp
 

--- a/tests/non_uniform_point_sampling.cpp
+++ b/tests/non_uniform_point_sampling.cpp
@@ -29,8 +29,12 @@
 
 inline namespace anonymous_namespace_workaround_non_uniform_point_sampling_cpp {
 
-struct DimX;
-struct DimY;
+struct DimX
+{
+};
+struct DimY
+{
+};
 
 struct DDimX : ddc::NonUniformPointSampling<DimX>
 {

--- a/tests/pdi/pdi.cpp
+++ b/tests/pdi/pdi.cpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <string>
+#include <string_view>
 
 #include <ddc/ddc.hpp>
 #include <ddc/pdi.hpp>

--- a/tests/periodic_sampling.cpp
+++ b/tests/periodic_sampling.cpp
@@ -13,8 +13,12 @@
 
 inline namespace anonymous_namespace_workaround_periodic_sampling_cpp {
 
-struct DimX;
-struct DimY;
+struct DimX
+{
+};
+struct DimY
+{
+};
 
 struct DDimX : ddc::PeriodicSampling<DimX>
 {

--- a/tests/relocatable_device_code_initialization.hpp
+++ b/tests/relocatable_device_code_initialization.hpp
@@ -8,11 +8,13 @@
 
 namespace rdc {
 
-struct DimX;
-
+struct DimX
+{
+};
 struct DDimX : ddc::UniformPointSampling<DimX>
 {
 };
+
 using DElemX = ddc::DiscreteElement<DDimX>;
 using DVectX = ddc::DiscreteVector<DDimX>;
 using DDomX = ddc::DiscreteDomain<DDimX>;

--- a/tests/splines/bsplines.cpp
+++ b/tests/splines/bsplines.cpp
@@ -23,7 +23,9 @@
 #include "test_utils.hpp"
 
 template <class T>
-struct BSplinesFixture;
+struct BSplinesFixture
+{
+};
 
 template <std::size_t D, std::size_t Nc, bool Periodic>
 struct BSplinesFixture<std::tuple<

--- a/tests/splines/bsplines.cpp
+++ b/tests/splines/bsplines.cpp
@@ -8,6 +8,7 @@
 #include <ios>
 #include <limits>
 #include <sstream>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <utility>

--- a/tests/splines/knots_as_interpolation_points.cpp
+++ b/tests/splines/knots_as_interpolation_points.cpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <ios>
 #include <sstream>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <utility>

--- a/tests/splines/knots_as_interpolation_points.cpp
+++ b/tests/splines/knots_as_interpolation_points.cpp
@@ -20,7 +20,9 @@
 inline namespace anonymous_namespace_workaround_knots_as_interpolation_points_cpp {
 
 template <class T>
-struct UniformBSplinesFixture;
+struct UniformBSplinesFixture
+{
+};
 
 template <bool IsPeriodic>
 struct UniformBSplinesFixture<std::tuple<std::integral_constant<bool, IsPeriodic>>>
@@ -44,7 +46,9 @@ struct UniformBSplinesFixture<std::tuple<std::integral_constant<bool, IsPeriodic
 };
 
 template <class T>
-struct NonUniformBSplinesFixture;
+struct NonUniformBSplinesFixture
+{
+};
 
 template <bool IsPeriodic>
 struct NonUniformBSplinesFixture<std::tuple<std::integral_constant<bool, IsPeriodic>>>

--- a/tests/splines/spline_traits.cpp
+++ b/tests/splines/spline_traits.cpp
@@ -38,7 +38,9 @@ struct DDimY : ddc::NonUniformPointSampling<DimY>
 };
 
 template <typename T>
-struct BSplinesTraits;
+struct BSplinesTraits
+{
+};
 
 template <typename ExecSpace1, std::size_t D1, typename ExecSpace2, std::size_t D2>
 struct BSplinesTraits<std::tuple<

--- a/tests/splines/spline_traits.cpp
+++ b/tests/splines/spline_traits.cpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <sstream>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <utility>

--- a/tests/splines/test_utils.hpp
+++ b/tests/splines/test_utils.hpp
@@ -36,10 +36,12 @@ template <class S>
 using to_tuple_t = ToTuple<S>::type;
 
 template <class TupleOfTuples, class Tuple>
-struct for_each_tuple_cat;
+struct ForEachTupleCat
+{
+};
 
 template <class... Tuples, class Tuple>
-struct for_each_tuple_cat<std::tuple<Tuples...>, Tuple>
+struct ForEachTupleCat<std::tuple<Tuples...>, Tuple>
 {
     using type = std::tuple<
             decltype(std::tuple_cat(std::declval<Tuples>(), std::declval<Tuple>()))...>;
@@ -47,7 +49,7 @@ struct for_each_tuple_cat<std::tuple<Tuples...>, Tuple>
 
 /// Construct a tuple of tuples that is the result of the concatenation of the tuples in TupleOfTuples with Tuple.
 template <class TupleOfTuples, class Tuple>
-using for_each_tuple_cat_t = for_each_tuple_cat<TupleOfTuples, Tuple>::type;
+using for_each_tuple_cat_t = ForEachTupleCat<TupleOfTuples, Tuple>::type;
 
 static_assert(std::is_same_v<
               for_each_tuple_cat_t<
@@ -60,11 +62,13 @@ static_assert(std::is_same_v<
               std::tuple<std::tuple<double, double, int>>>);
 
 template <class InTupleOfTuples, class OutTupleOfTuples>
-struct cartesian_product_impl;
+struct CartesianProductImpl
+{
+};
 
 template <class... HeadArgs, class... TailTuples, class OutTupleOfTuples>
-struct cartesian_product_impl<std::tuple<std::tuple<HeadArgs...>, TailTuples...>, OutTupleOfTuples>
-    : cartesian_product_impl<
+struct CartesianProductImpl<std::tuple<std::tuple<HeadArgs...>, TailTuples...>, OutTupleOfTuples>
+    : CartesianProductImpl<
               std::tuple<TailTuples...>,
               decltype(std::tuple_cat(
                       std::declval<
@@ -73,7 +77,7 @@ struct cartesian_product_impl<std::tuple<std::tuple<HeadArgs...>, TailTuples...>
 };
 
 template <class OutTupleOfTuples>
-struct cartesian_product_impl<std::tuple<>, OutTupleOfTuples>
+struct CartesianProductImpl<std::tuple<>, OutTupleOfTuples>
 {
     using type = OutTupleOfTuples;
 };
@@ -81,9 +85,9 @@ struct cartesian_product_impl<std::tuple<>, OutTupleOfTuples>
 /// Generate a std::tuple cartesian product from multiple tuple-like structures (std::tuple, std::integer_sequence and std::pair)
 /// Do not rely on the ordering result.
 template <class... InTuplesLike>
-using cartesian_product_t = cartesian_product_impl<
-        std::tuple<to_tuple_t<InTuplesLike>...>,
-        std::tuple<std::tuple<>>>::type;
+using cartesian_product_t
+        = CartesianProductImpl<std::tuple<to_tuple_t<InTuplesLike>...>, std::tuple<std::tuple<>>>::
+                type;
 
 static_assert(std::is_same_v<
               cartesian_product_t<std::tuple<int, float>, std::tuple<double>>,

--- a/tests/strided_discrete_domain.cpp
+++ b/tests/strided_discrete_domain.cpp
@@ -314,14 +314,6 @@ TEST(StridedDiscreteDomainTest, Select)
     EXPECT_EQ(ddc::select<DDimY>(dom_x_y), dom_y);
 }
 
-// TEST(StridedDiscreteDomainTest, CartesianProduct)
-// {
-//     EXPECT_TRUE((std::is_same_v<ddc::cartesian_prod_t<>, ddc::DiscreteDomain<>>));
-//     EXPECT_TRUE((std::is_same_v<ddc::cartesian_prod_t<DDomX>, DDomX>));
-//     EXPECT_TRUE((std::is_same_v<ddc::cartesian_prod_t<DDomX, DDomY, DDomZ>, DDomXYZ>));
-//     EXPECT_TRUE((std::is_same_v<ddc::cartesian_prod_t<DDomZY, DDomX>, DDomZYX>));
-// }
-
 void TestDeviceForEachStritedSerialDevice1D(
         ddc::ChunkSpan<
                 int,

--- a/tests/type_seq.cpp
+++ b/tests/type_seq.cpp
@@ -10,45 +10,59 @@
 
 inline namespace anonymous_namespace_workaround_type_seq_cpp {
 
-struct a;
-struct b;
-struct c;
-struct d;
-struct e;
-struct y;
-struct z;
+struct T0
+{
+};
+struct T1
+{
+};
+struct T2
+{
+};
+struct T3
+{
+};
+struct T4
+{
+};
+struct T5
+{
+};
+struct T6
+{
+};
 
 } // namespace anonymous_namespace_workaround_type_seq_cpp
 
 TEST(TypeSeqTest, Size)
 {
     using Empty = ddc::detail::TypeSeq<>;
-    using A = ddc::detail::TypeSeq<a, b, c>;
+    using A = ddc::detail::TypeSeq<T0, T1, T2>;
     EXPECT_EQ((ddc::type_seq_size_v<Empty>), 0);
     EXPECT_EQ((ddc::type_seq_size_v<A>), 3);
 }
 
 TEST(TypeSeqTest, Rank)
 {
-    using A = ddc::detail::TypeSeq<a, b, c>;
-    EXPECT_EQ((ddc::type_seq_rank_v<a, A>), 0);
-    EXPECT_EQ((ddc::type_seq_rank_v<b, A>), 1);
-    EXPECT_EQ((ddc::type_seq_rank_v<c, A>), 2);
+    using A = ddc::detail::TypeSeq<T0, T1, T2>;
+    EXPECT_EQ((ddc::type_seq_rank_v<T0, A>), 0);
+    EXPECT_EQ((ddc::type_seq_rank_v<T1, A>), 1);
+    EXPECT_EQ((ddc::type_seq_rank_v<T2, A>), 2);
 }
 
 TEST(TypeSeqTest, Element)
 {
-    using A = ddc::detail::TypeSeq<a, b, c>;
-    EXPECT_TRUE((std::is_same_v<a, ddc::type_seq_element_t<0, A>>));
-    EXPECT_TRUE((std::is_same_v<b, ddc::type_seq_element_t<1, A>>));
-    EXPECT_TRUE((std::is_same_v<c, ddc::type_seq_element_t<2, A>>));
+    using A = ddc::detail::TypeSeq<T0, T1, T2>;
+    EXPECT_TRUE((std::is_same_v<T0, ddc::type_seq_element_t<0, A>>));
+    EXPECT_TRUE((std::is_same_v<T1, ddc::type_seq_element_t<1, A>>));
+    EXPECT_TRUE((std::is_same_v<T2, ddc::type_seq_element_t<2, A>>));
 }
 
 TEST(TypeSeqTest, SameTags)
 {
-    using A = ddc::detail::TypeSeq<a, b, c>;
-    using B = ddc::detail::TypeSeq<z, c, y>;
-    using C = ddc::detail::TypeSeq<c, b, a>;
+    using A = ddc::detail::TypeSeq<T0, T1, T2>;
+    using B = ddc::detail::TypeSeq<T6, T2, T5>;
+    using C = ddc::detail::TypeSeq<T2, T1, T0>;
     EXPECT_FALSE((ddc::type_seq_same_v<A, B>));
     EXPECT_FALSE((ddc::type_seq_same_v<B, A>));
     EXPECT_TRUE((ddc::type_seq_same_v<A, C>));
@@ -59,49 +73,49 @@ TEST(TypeSeqTest, SameTags)
 
 TEST(TypeSeqTest, Remove)
 {
-    using A = ddc::detail::TypeSeq<a, b, c>;
-    using B = ddc::detail::TypeSeq<z, c, y>;
+    using A = ddc::detail::TypeSeq<T0, T1, T2>;
+    using B = ddc::detail::TypeSeq<T6, T2, T5>;
     using R = ddc::type_seq_remove_t<A, B>;
-    using ExpectedR = ddc::detail::TypeSeq<a, b>;
+    using ExpectedR = ddc::detail::TypeSeq<T0, T1>;
     EXPECT_TRUE((ddc::type_seq_same_v<R, ExpectedR>));
 }
 
 TEST(TypeSeqTest, Merge)
 {
-    using A = ddc::detail::TypeSeq<a, b, c>;
-    using B = ddc::detail::TypeSeq<z, c, y>;
+    using A = ddc::detail::TypeSeq<T0, T1, T2>;
+    using B = ddc::detail::TypeSeq<T6, T2, T5>;
     using R = ddc::type_seq_merge_t<A, B>;
-    using ExpectedR = ddc::detail::TypeSeq<a, b, c, z, y>;
+    using ExpectedR = ddc::detail::TypeSeq<T0, T1, T2, T6, T5>;
     EXPECT_TRUE((ddc::type_seq_same_v<R, ExpectedR>));
 }
 
 TEST(TypeSeqTest, Cat)
 {
-    using A = ddc::detail::TypeSeq<a, b, c>;
-    using B = ddc::detail::TypeSeq<z, c, y>;
+    using A = ddc::detail::TypeSeq<T0, T1, T2>;
+    using B = ddc::detail::TypeSeq<T6, T2, T5>;
     using R = ddc::type_seq_cat_t<A, B>;
-    using ExpectedR = ddc::detail::TypeSeq<a, b, c, z, c, y>;
+    using ExpectedR = ddc::detail::TypeSeq<T0, T1, T2, T6, T2, T5>;
     EXPECT_TRUE((ddc::type_seq_same_v<R, ExpectedR>));
 }
 
 TEST(TypeSeqTest, Replace)
 {
-    using A = ddc::detail::TypeSeq<a, b, c, d, e>;
-    using B = ddc::detail::TypeSeq<b, d>;
-    using C = ddc::detail::TypeSeq<y, z>;
+    using A = ddc::detail::TypeSeq<T0, T1, T2, T3, T4>;
+    using B = ddc::detail::TypeSeq<T1, T3>;
+    using C = ddc::detail::TypeSeq<T5, T6>;
     using R = ddc::type_seq_replace_t<A, B, C>;
-    using ExpectedR = ddc::detail::TypeSeq<a, y, c, z, e>;
+    using ExpectedR = ddc::detail::TypeSeq<T0, T5, T2, T6, T4>;
     EXPECT_TRUE((ddc::type_seq_same_v<R, ExpectedR>));
 }
 
 TEST(TypeSeqTest, IsUnique)
 {
-    using A = ddc::detail::TypeSeq<a, b, c, d, e>;
+    using A = ddc::detail::TypeSeq<T0, T1, T2, T3, T4>;
     using B = ddc::detail::TypeSeq<>;
-    using C = ddc::detail::TypeSeq<y>;
-    using D = ddc::detail::TypeSeq<y, y>;
-    using E = ddc::detail::TypeSeq<a, b, c, d, b, e>;
-    using F = ddc::detail::TypeSeq<a, b, a, c, b, a, d, b, e, a>;
+    using C = ddc::detail::TypeSeq<T5>;
+    using D = ddc::detail::TypeSeq<T5, T5>;
+    using E = ddc::detail::TypeSeq<T0, T1, T2, T3, T1, T4>;
+    using F = ddc::detail::TypeSeq<T0, T1, T0, T2, T1, T0, T3, T1, T4, T0>;
     EXPECT_TRUE((ddc::type_seq_is_unique_v<A>));
     EXPECT_TRUE((ddc::type_seq_is_unique_v<B>));
     EXPECT_TRUE((ddc::type_seq_is_unique_v<C>));

--- a/tests/uniform_point_sampling.cpp
+++ b/tests/uniform_point_sampling.cpp
@@ -13,8 +13,12 @@
 
 inline namespace anonymous_namespace_workaround_uniform_point_sampling_cpp {
 
-struct DimX;
-struct DimY;
+struct DimX
+{
+};
+struct DimY
+{
+};
 
 struct DDimX : ddc::UniformPointSampling<DimX>
 {


### PR DESCRIPTION
- Prefer definitions over simple declarations and fix naming (revealed by adding actual definitions)
- RebindDomain is renamed Rebind and general definition in type_seq.hpp
- Remove cartesian_prod_t only defined for DiscreteDomain and barely used in subprojects
