### PR TITLE
Test Spack installation in docker

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -98,11 +98,20 @@ jobs:
       - name: Generate documentation
         run: |
           cat<<-EOF > run.sh
-            set -xe
-            git config --global --add safe.directory '*'
+            set -e
+
+            . spack/share/spack/setup-env.sh
+            spack env activate ddc-cpu
+
             cmake \
-                -D DDC_BUILD_DOCUMENTATION=ON \
+                -D BUILD_TESTING=OFF \
                 -D CMAKE_CXX_STANDARD=20 \
+                -D DDC_BUILD_BENCHMARKS=OFF \
+                -D DDC_BUILD_DOCUMENTATION=ON \
+                -D DDC_BUILD_EXAMPLES=ON \
+                -D DDC_BUILD_KERNELS_FFT=ON \
+                -D DDC_BUILD_KERNELS_SPLINES=ON \
+                -D DDC_BUILD_PDI_WRAPPER=ON \
                 -D DOXYGEN_EXTRACT_ALL=NO \
                 -D DOXYGEN_WARN_IF_UNDOCUMENTED=YES \
                 -D DOXYGEN_WARN_IF_DOC_ERROR=YES \
@@ -110,7 +119,6 @@ jobs:
                 -D DOXYGEN_WARN_NO_PARAMDOC=YES \
                 -D DOXYGEN_WARN_IF_UNDOC_ENUM_VAL=YES \
                 -D DOXYGEN_WARN_AS_ERROR=NO \
-                -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
                 -B build \
                 -S /src
             cmake --build build --verbose --target doc
@@ -159,16 +167,25 @@ jobs:
       - name: Build site
         run: |
           cat<<-EOF > run.sh
-            set -xe
-            git config --global --add safe.directory '*'
+            set -e
+
+            . spack/share/spack/setup-env.sh
+            spack env activate ddc-cpu
+
             export CC=clang
             export CXX=clang++
             cmake \
-                -D DDC_BUILD_DOCUMENTATION=ON \
+                -D BUILD_TESTING=OFF \
                 -D CMAKE_CXX_STANDARD=20 \
                 -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
                 -D CMAKE_VERIFY_INTERFACE_HEADER_SETS=ON \
-                -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+                -D DDC_BUILD_BENCHMARKS=OFF \
+                -D DDC_BUILD_DOCUMENTATION=ON \
+                -D DDC_BUILD_EXAMPLES=ON \
+                -D DDC_BUILD_KERNELS_FFT=ON \
+                -D DDC_BUILD_KERNELS_SPLINES=ON \
+                -D DDC_BUILD_PDI_WRAPPER=ON \
+                -D DDC_BUILD_DOCUMENTATION=ON \
                 -B build \
                 -S /src
             cmake --build build --verbose --target doc || true

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -100,9 +100,6 @@ jobs:
           cat<<-EOF > run.sh
             set -e
 
-            . spack/share/spack/setup-env.sh
-            spack env activate ddc-cpu
-
             cmake \
                 -D BUILD_TESTING=OFF \
                 -D CMAKE_CXX_STANDARD=20 \
@@ -168,9 +165,6 @@ jobs:
         run: |
           cat<<-EOF > run.sh
             set -e
-
-            . spack/share/spack/setup-env.sh
-            spack env activate ddc-cpu
 
             export CC=clang
             export CXX=clang++

--- a/.github/workflows/tests-ubuntu.yaml
+++ b/.github/workflows/tests-ubuntu.yaml
@@ -155,9 +155,6 @@ jobs:
           cat<<-'EOF' > run.sh
             set -e
 
-            . /data/spack/share/spack/setup-env.sh
-            spack env activate ddc-cpu
-
             export CMAKE_BUILD_PARALLEL_LEVEL=4
             export CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}}
 
@@ -287,9 +284,6 @@ jobs:
           cat<<-'EOF' > run.sh
             set -e
 
-            . spack/share/spack/setup-env.sh
-            spack env activate ddc-${{matrix.backend.name}}
-
             export DDC_ROOT=$PWD/opt/ddc
 
             export CMAKE_BUILD_PARALLEL_LEVEL=4
@@ -408,9 +402,6 @@ jobs:
           cat<<-'EOF' > run.sh
             set -e
 
-            . spack/share/spack/setup-env.sh
-            spack env activate ddc-cpu
-
             export CMAKE_BUILD_PARALLEL_LEVEL=4
             export CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}}
 
@@ -506,9 +497,6 @@ jobs:
         run: |
           cat<<-'EOF' > run.sh
             set -e
-
-            . spack/share/spack/setup-env.sh
-            spack env activate ddc-cpu
 
             export CMAKE_BUILD_PARALLEL_LEVEL=4
             export CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}}

--- a/.github/workflows/tests-ubuntu.yaml
+++ b/.github/workflows/tests-ubuntu.yaml
@@ -153,8 +153,10 @@ jobs:
       - name: Coverage test
         run: |
           cat<<-'EOF' > run.sh
-            set -xe
-            git config --global --add safe.directory '*'
+            set -e
+
+            . /data/spack/share/spack/setup-env.sh
+            spack env activate ddc-cpu
 
             export CMAKE_BUILD_PARALLEL_LEVEL=4
             export CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}}
@@ -164,17 +166,22 @@ jobs:
 
             cmake \
               -D CMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
-              -D CMAKE_CXX_FLAGS="-DNDEBUG -DKOKKOSKERNELS_DEBUG_LEVEL=0 --coverage -fprofile-update=atomic" \
+              -D CMAKE_CXX_FLAGS="-DNDEBUG --coverage -fprofile-update=atomic" \
               -D DDC_BUILD_BENCHMARKS=OFF \
+              -D DDC_BUILD_KERNELS_FFT=ON \
+              -D DDC_BUILD_KERNELS_SPLINES=ON \
+              -D DDC_BUILD_PDI_WRAPPER=ON \
               -D DDC_BUILD_EXAMPLES=OFF \
-              -D Kokkos_ENABLE_DEPRECATED_CODE_4=OFF \
-              -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+              -D DDC_GTest_DEPENDENCY_POLICY=INSTALLED \
+              -D DDC_Kokkos_DEPENDENCY_POLICY=INSTALLED \
+              -D DDC_KokkosFFT_DEPENDENCY_POLICY=INSTALLED \
+              -D DDC_KokkosKernels_DEPENDENCY_POLICY=INSTALLED \
               -B build
 
             cmake --build build
             ctest --test-dir build
 
-            /root/.local/bin/gcovr \
+            gcovr \
               --exclude-throw-branches \
               --filter src/ddc \
               --lcov coverage.lcov \
@@ -208,22 +215,18 @@ jobs:
             c_compiler: 'gcc'
             cxx_compiler: 'g++'
             ddc_extra_cxx_flags: '-Wextra-semi -Wold-style-cast'
-            kokkos_extra_cmake_flags: ''
           - name: 'cpu'
             c_compiler: 'clang'
             cxx_compiler: 'clang++'
             ddc_extra_cxx_flags: '-Wextra-semi -Wextra-semi-stmt -Wold-style-cast'
-            kokkos_extra_cmake_flags: ''
           - name: 'cuda'
             c_compiler: '${CUDA_GCC}'
             cxx_compiler: '${CUDA_GXX}'
             ddc_extra_cxx_flags: ''
-            kokkos_extra_cmake_flags: '-D Kokkos_ENABLE_CUDA=ON -D Kokkos_ENABLE_CUDA_CONSTEXPR=ON -D Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON -D Kokkos_ARCH_AMPERE80=ON'
           - name: 'hip'
             c_compiler: 'hipcc'
             cxx_compiler: 'hipcc'
             ddc_extra_cxx_flags: ''
-            kokkos_extra_cmake_flags: '-D Kokkos_ENABLE_HIP=ON -D Kokkos_ENABLE_HIP_RELOCATABLE_DEVICE_CODE=ON -D Kokkos_ENABLE_ROCTHRUST=OFF -D Kokkos_ARCH_AMD_GFX90A=ON'
         cxx_version: ['20', '23']
         build_type:
           - cmake_build_type: 'Release'
@@ -282,15 +285,12 @@ jobs:
         id: test
         run: |
           cat<<-'EOF' > run.sh
-            set -xe
-            git config --global --add safe.directory '*'
+            set -e
 
-            export benchmark_ROOT=$PWD/opt/benchmark
+            . spack/share/spack/setup-env.sh
+            spack env activate ddc-${{matrix.backend.name}}
+
             export DDC_ROOT=$PWD/opt/ddc
-            export GTest_ROOT=$PWD/opt/gtest
-            export Kokkos_ROOT=$PWD/opt/kokkos
-            export KokkosFFT_ROOT=$PWD/opt/kokkos-fft
-            export KokkosKernels_ROOT=$PWD/opt/kokkos-kernels
 
             export CMAKE_BUILD_PARALLEL_LEVEL=4
             export CMAKE_BUILD_TYPE=${{matrix.build_type.cmake_build_type}}
@@ -298,73 +298,21 @@ jobs:
             export CC=${{matrix.backend.c_compiler}}
             export CXX=${{matrix.backend.cxx_compiler}}
 
-            cmake \
-              -D CMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
-              -D BENCHMARK_ENABLE_GTEST_TESTS=OFF \
-              -D BENCHMARK_ENABLE_TESTING=OFF \
-              -D BENCHMARK_INSTALL_DOCS=OFF \
-              -D BENCHMARK_USE_BUNDLED_GTEST=OFF \
-              -B build \
-              -S /src/vendor/benchmark
-            cmake --build build
-            cmake --install build --prefix $benchmark_ROOT
-            rm -rf build
-
-            cmake \
-              -D CMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
-              -B build \
-              -S /src/vendor/googletest
-            cmake --build build
-            cmake --install build --prefix $GTest_ROOT
-            rm -rf build
-
-            cmake \
-              -D CMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
-              -D Kokkos_ENABLE_DEPRECATED_CODE_4=OFF \
-              -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
-              -D Kokkos_ENABLE_SERIAL=ON \
-              ${{matrix.backend.kokkos_extra_cmake_flags}} \
-              -B build \
-              -S /src/vendor/kokkos
-            cmake --build build
-            cmake --install build --prefix $Kokkos_ROOT
-            rm -rf build
-
-            cmake \
-              -D CMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
-              -D KokkosFFT_ENABLE_FFTW=ON \
-              -B build \
-              -S /src/vendor/kokkos-fft
-            cmake --build build
-            cmake --install build --prefix $KokkosFFT_ROOT
-            rm -rf build
-
-            cmake \
-              -D CMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
-              -D KokkosKernels_ADD_DEFAULT_ETI=OFF \
-              -D KokkosKernels_ENABLE_ALL_COMPONENTS=OFF \
-              -D KokkosKernels_ENABLE_COMPONENT_BLAS=ON \
-              -D KokkosKernels_ENABLE_COMPONENT_BATCHED=ON \
-              -D KokkosKernels_ENABLE_COMPONENT_LAPACK=OFF \
-              -D KokkosKernels_ENABLE_TPL_BLAS=OFF \
-              -D KokkosKernels_ENABLE_TPL_CUSOLVER=OFF \
-              -D KokkosKernels_ENABLE_TPL_LAPACK=OFF \
-              -B build \
-              -S /src/vendor/kokkos-kernels
-            cmake --build build
-            cmake --install build --prefix $KokkosKernels_ROOT
-            rm -rf build
-
             export NVCC_PREPEND_FLAGS="-Werror all-warnings"
 
             cmake \
               -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-sign-compare -pedantic-errors ${{matrix.build_type.cxx_flags}} ${{matrix.backend.ddc_extra_cxx_flags}}" \
               -D CMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
               -D DDC_BUILD_BENCHMARKS=ON \
+              -D DDC_BUILD_KERNELS_FFT=ON \
+              -D DDC_BUILD_KERNELS_SPLINES=ON \
+              -D DDC_BUILD_PDI_WRAPPER=ON \
+              -D DDC_BUILD_EXAMPLES=ON \
               -D DDC_benchmark_DEPENDENCY_POLICY=INSTALLED \
               -D DDC_GTest_DEPENDENCY_POLICY=INSTALLED \
               -D DDC_Kokkos_DEPENDENCY_POLICY=INSTALLED \
               -D DDC_KokkosFFT_DEPENDENCY_POLICY=INSTALLED \
+              -D DDC_KokkosKernels_DEPENDENCY_POLICY=INSTALLED \
               -D DDC_SPLINES_TEST_DEGREE_MIN=${{env.DDC_SPLINES_TEST_DEGREE_MIN}} \
               -D DDC_SPLINES_TEST_DEGREE_MAX=${{env.DDC_SPLINES_TEST_DEGREE_MAX}} \
               -B build \
@@ -458,8 +406,10 @@ jobs:
         id: test
         run: |
           cat<<-'EOF' > run.sh
-            set -xe
-            git config --global --add safe.directory '*'
+            set -e
+
+            . spack/share/spack/setup-env.sh
+            spack env activate ddc-cpu
 
             export CMAKE_BUILD_PARALLEL_LEVEL=4
             export CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}}
@@ -471,8 +421,15 @@ jobs:
               -D CMAKE_CXX_FLAGS="-fsanitize=${{matrix.sanitizer}} -fno-omit-frame-pointer" \
               -D CMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
               -D DDC_BUILD_BENCHMARKS=ON \
-              -D Kokkos_ENABLE_DEPRECATED_CODE_4=OFF \
-              -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+              -D DDC_BUILD_KERNELS_FFT=ON \
+              -D DDC_BUILD_KERNELS_SPLINES=ON \
+              -D DDC_BUILD_PDI_WRAPPER=ON \
+              -D DDC_BUILD_EXAMPLES=ON \
+              -D DDC_benchmark_DEPENDENCY_POLICY=INSTALLED \
+              -D DDC_GTest_DEPENDENCY_POLICY=INSTALLED \
+              -D DDC_Kokkos_DEPENDENCY_POLICY=INSTALLED \
+              -D DDC_KokkosFFT_DEPENDENCY_POLICY=INSTALLED \
+              -D DDC_KokkosKernels_DEPENDENCY_POLICY=INSTALLED \
               -B build \
               -S /src
             cmake --build build
@@ -548,8 +505,10 @@ jobs:
       - name: clang-tidy
         run: |
           cat<<-'EOF' > run.sh
-            set -xe
-            git config --global --add safe.directory '*'
+            set -e
+
+            . spack/share/spack/setup-env.sh
+            spack env activate ddc-cpu
 
             export CMAKE_BUILD_PARALLEL_LEVEL=4
             export CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}}
@@ -558,15 +517,22 @@ jobs:
             export CXX=${{matrix.backend.cxx_compiler}}
 
             cmake \
+              -D BUILD_TESTING=ON \
+              -D CMAKE_CXX_CLANG_TIDY=clang-tidy \
               -D CMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
-              -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
               -D DDC_BUILD_BENCHMARKS=ON \
-              -D Kokkos_ENABLE_DEPRECATED_CODE_4=OFF \
-              -D Kokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+              -D DDC_BUILD_KERNELS_FFT=ON \
+              -D DDC_BUILD_KERNELS_SPLINES=ON \
+              -D DDC_BUILD_PDI_WRAPPER=ON \
+              -D DDC_BUILD_EXAMPLES=ON \
+              -D DDC_benchmark_DEPENDENCY_POLICY=INSTALLED \
+              -D DDC_GTest_DEPENDENCY_POLICY=INSTALLED \
+              -D DDC_Kokkos_DEPENDENCY_POLICY=INSTALLED \
+              -D DDC_KokkosFFT_DEPENDENCY_POLICY=INSTALLED \
+              -D DDC_KokkosKernels_DEPENDENCY_POLICY=INSTALLED \
               -B build \
               -S /src
-
-            find /src/benchmarks /src/examples /src/tests -name '*.cpp' -exec clang-tidy -p build -header-filter="(/src/src/ddc/.*|/src/tests/.*)" '{}' '+'
+            cmake --build build
           EOF
 
           docker run \

--- a/.typos.toml
+++ b/.typos.toml
@@ -7,3 +7,4 @@
 iy = "iy"
 iz = "iz"
 ND = "ND"
+hsa = "hsa"

--- a/docker/doxygen/Dockerfile
+++ b/docker/doxygen/Dockerfile
@@ -35,18 +35,18 @@ RUN chmod +x /bin/bash_run.sh \
  && rm -rf /var/lib/apt/lists/* \
  && useradd -d /data -m -U ci
 
- RUN apt-get update -y \
-  && apt-get install -y --no-install-recommends file bzip2 ca-certificates g++ gcc gfortran git gzip lsb-release patch python3 tar unzip xz-utils zstd
+RUN apt-get update -y \
+ && apt-get install -y --no-install-recommends file bzip2 ca-certificates g++ gcc gfortran git gzip lsb-release patch python3 tar unzip xz-utils zstd
 
- USER ci:ci
- WORKDIR /data
+USER ci:ci
+WORKDIR /data
 
- COPY spack-env /data/spack-env
- RUN git clone --branch v1.1.1 --depth 1 https://github.com/spack/spack.git \
-  && . /data/spack/share/spack/setup-env.sh \
-  && spack env create ddc-cpu /data/spack-env/spack-cpu.yaml \
-  && spack --env ddc-cpu repo update \
-  && spack --env ddc-cpu install --fail-fast
+COPY spack-env /data/spack-env
+RUN git clone --branch v1.1.1 --depth 1 https://github.com/spack/spack.git \
+ && . /data/spack/share/spack/setup-env.sh \
+ && spack env create ddc /data/spack-env/spack-cpu.yaml \
+ && spack --env ddc repo update \
+ && spack --env ddc install --fail-fast
 
- ENTRYPOINT ["/bin/bash_run.sh"]
- CMD ["/bin/bash", "-li"]
+ENTRYPOINT ["/bin/bash_run.sh"]
+CMD ["/bin/bash", "-li"]

--- a/docker/doxygen/Dockerfile
+++ b/docker/doxygen/Dockerfile
@@ -6,14 +6,9 @@ FROM ubuntu:noble@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7
 
 LABEL "org.opencontainers.image.source"="https://github.com/CExA-project/ddc"
 
-ARG CMAKE_VERSION=4.2.3
-ARG GINKGO_VERSION=1.11.0
-
 COPY bash_run.sh /bin/
 ENV BASH_ENV=/etc/profile
 SHELL ["/bin/bash", "-c"]
-
-ENV PATH="/opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin${PATH:+:${PATH}}"
 
 RUN chmod +x /bin/bash_run.sh \
  && export DEBIAN_FRONTEND=noninteractive \
@@ -25,29 +20,13 @@ RUN chmod +x /bin/bash_run.sh \
     apt-utils \
     ca-certificates \
     wget \
- && wget -O /usr/share/keyrings/pdidev-archive-keyring.gpg https://repo.pdi.dev/ubuntu/pdidev-archive-keyring.gpg \
- && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/pdidev-archive-keyring.gpg] https://repo.pdi.dev/ubuntu noble main" > /etc/apt/sources.list.d/pdi.list \
  && apt-get update -y \
  && apt-get install -y --no-install-recommends \
-    build-essential \
     clang \
     cm-super-minimal \
     doxygen-latex \
     ghostscript \
-    git \
     graphviz \
-    libfftw3-dev \
-    liblapacke-dev \
-    libpdi-dev \
-    pkg-config \
- && wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz \
- && tar -xvf cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz --directory /opt \
- && rm -f cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz \
- && git clone --branch v${GINKGO_VERSION} --depth 1 https://github.com/ginkgo-project/ginkgo.git \
- && cmake -DCMAKE_BUILD_TYPE=Release -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF -DGINKGO_BUILD_BENCHMARKS=OFF -B ginkgo/build -S ginkgo \
- && cmake --build ginkgo/build \
- && cmake --install ginkgo/build --prefix /usr \
- && rm -rf ginkgo \
  && apt-get purge -y \
     apt-transport-https \
  && apt-get autoremove -y \
@@ -56,8 +35,18 @@ RUN chmod +x /bin/bash_run.sh \
  && rm -rf /var/lib/apt/lists/* \
  && useradd -d /data -m -U ci
 
-USER ci:ci
-WORKDIR /data
+ RUN apt-get update -y \
+  && apt-get install -y --no-install-recommends file bzip2 ca-certificates g++ gcc gfortran git gzip lsb-release patch python3 tar unzip xz-utils zstd
 
-ENTRYPOINT ["/bin/bash_run.sh"]
-CMD ["/bin/bash", "-li"]
+ USER ci:ci
+ WORKDIR /data
+
+ COPY spack-env /data/spack-env
+ RUN git clone --branch v1.1.1 --depth 1 https://github.com/spack/spack.git \
+  && . /data/spack/share/spack/setup-env.sh \
+  && spack env create ddc-cpu /data/spack-env/spack-cpu.yaml \
+  && spack --env ddc-cpu repo update \
+  && spack --env ddc-cpu install --fail-fast
+
+ ENTRYPOINT ["/bin/bash_run.sh"]
+ CMD ["/bin/bash", "-li"]

--- a/docker/doxygen/bash_run.sh
+++ b/docker/doxygen/bash_run.sh
@@ -5,5 +5,7 @@
 # SPDX-License-Identifier: MIT
 
 . /etc/profile
+. /data/spack/share/spack/setup-env.sh
+spack env activate ddc
 
 exec "$@"

--- a/docker/doxygen/spack-env/spack-cpu.yaml
+++ b/docker/doxygen/spack-env/spack-cpu.yaml
@@ -1,0 +1,44 @@
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
+---
+spack:
+  concretizer:
+    reuse: false
+    unify: true
+  packages:
+    all:
+      require:
+        - 'target=x86_64'
+        - '~cuda'
+        - '~rocm'
+        - '~openmp'
+        - '~mpi'
+        - '~fortran'
+    c:
+      require: 'gcc@13'
+    cxx:
+      require: 'gcc@13'
+    fortran:
+      require: 'gcc@13'
+    lapack:
+      require: 'openblas@0.3'
+  repos:
+    builtin:
+      tag: v2026.03.0
+  specs:
+    - 'gcc@13'
+    - 'cmake@4.2'
+    - 'ginkgo@1.11'
+    - 'kokkos@5.0'
+    - 'kokkos-fft@1.0 host_backend=fftw-serial'
+    - 'kokkos-kernels@5.0'
+    - 'lapack'
+    - 'paraconf@1.0'
+    - 'pkgconfig'
+    - 'pdi@1.10.1:1.10'
+  view:
+    default:
+      root: .spack-env/view
+      exclude: ['gcc-runtime']

--- a/docker/latest/Dockerfile
+++ b/docker/latest/Dockerfile
@@ -108,9 +108,9 @@ WORKDIR /data
 COPY spack-env /data/spack-env
 RUN git clone --branch v1.1.1 --depth 1 https://github.com/spack/spack.git \
  && . /data/spack/share/spack/setup-env.sh \
- && spack env create ddc-${BACKEND} /data/spack-env/spack-${BACKEND}.yaml \
- && spack --env ddc-${BACKEND} repo update \
- && spack --env ddc-${BACKEND} install --fail-fast
+ && spack env create ddc /data/spack-env/spack-${BACKEND}.yaml \
+ && spack --env ddc repo update \
+ && spack --env ddc install --fail-fast
 
 ENTRYPOINT ["/bin/bash_run.sh"]
 CMD ["/bin/bash", "-li"]

--- a/docker/latest/Dockerfile
+++ b/docker/latest/Dockerfile
@@ -7,21 +7,17 @@ FROM ubuntu:noble@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7
 LABEL "org.opencontainers.image.source"="https://github.com/CExA-project/ddc"
 
 ARG BACKEND
-ARG AMDGPU_VERSION=6.4.4
-ARG CMAKE_VERSION=4.2.3
+ARG AMDGPU_VERSION=6.4.3
 ARG CUDA_MAJOR_VERSION=12
 ARG CUDA_MINOR_VERSION=9
-ARG GCOVR_VERSION=8.6
-ARG GINKGO_VERSION=1.11.0
 ARG LLVM_VERSION=22
-ARG ROCM_VERSION=6.4.4
+ARG ROCM_VERSION=6.4.3
 
 COPY bash_run.sh /bin/
 ENV BASH_ENV=/etc/profile
 SHELL ["/bin/bash", "-c"]
 
 ENV PATH="/usr/local/cuda-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}/bin${PATH:+:${PATH}}"
-ENV PATH="/opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin${PATH:+:${PATH}}"
 ENV PATH="${PATH:+$PATH:}/opt/rocm-${ROCM_VERSION}/bin"
 ENV CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:+$CMAKE_PREFIX_PATH:}/opt/rocm-${ROCM_VERSION}"
 
@@ -37,9 +33,7 @@ RUN chmod +x /bin/bash_run.sh \
     gpg \
     wget \
  && mkdir --parents --mode=0755 /etc/apt/keyrings \
- && wget -O /usr/share/keyrings/pdidev-archive-keyring.gpg https://repo.pdi.dev/ubuntu/pdidev-archive-keyring.gpg \
  && wget -O /usr/share/keyrings/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
- && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/pdidev-archive-keyring.gpg] https://repo.pdi.dev/ubuntu noble main" > /etc/apt/sources.list.d/pdi.list \
  && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/apt.llvm.org.asc] http://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list \
  && case "x${BACKEND}" in \
     "xhip") \
@@ -53,21 +47,6 @@ RUN chmod +x /bin/bash_run.sh \
       && wget -O /etc/apt/preferences.d/cuda-repository-pin-600 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-ubuntu2404.pin \
  ;; esac \
  && apt-get update -y \
- && apt-get install -y --no-install-recommends \
-    build-essential \
-    git \
-    libfftw3-dev \
-    libhwloc-dev \
-    liblapacke-dev \
-    libpdi-dev \
-    pdiplugin-decl-hdf5-serial \
-    pdiplugin-trace \
-    pdiplugin-user-code \
-    pkg-config \
-    pipx \
-    python3 \
- && python3 -m pipx install gcovr==${GCOVR_VERSION} \
- && python3 -m pipx ensurepath \
  && case "${BACKEND}" in \
     "cpu") \
       apt-get install -y --no-install-recommends \
@@ -84,9 +63,11 @@ RUN chmod +x /bin/bash_run.sh \
       libcublas-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
       libcufft-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
       libcurand-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
+      libcusolver-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
       libcusparse-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
       libnvjitlink-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
       gcc-12 \
+      gfortran-12 \
       g++-12 \
  ;; "hip") \
       apt-get install -y --no-install-recommends \
@@ -103,21 +84,6 @@ RUN chmod +x /bin/bash_run.sh \
       && echo "/opt/rocm/lib64" >> /etc/ld.so.conf.d/rocm.conf \
       && ldconfig \
  ;; esac \
- && wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz \
- && tar -xvf cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz --directory /opt \
- && rm -f cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz \
- && git clone --branch v${GINKGO_VERSION} --depth 1 https://github.com/ginkgo-project/ginkgo.git \
- && case "${BACKEND}" in \
-    "cpu") \
-      cmake -DCMAKE_BUILD_TYPE=Release -DGINKGO_BUILD_OMP=ON -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF -DGINKGO_BUILD_BENCHMARKS=OFF -B ginkgo/build -S ginkgo \
- ;; "cuda") \
-      cmake -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_CUDA_HOST_COMPILER=g++-12 -DCMAKE_BUILD_TYPE=Release -DGINKGO_CUDA_ARCHITECTURES=80 -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF -DGINKGO_BUILD_BENCHMARKS=OFF -B ginkgo/build -S ginkgo \
- ;; "hip") \
-      cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_HIP_ARCHITECTURES=gfx90a -DGINKGO_BUILD_HIP=ON -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF -DGINKGO_BUILD_BENCHMARKS=OFF -B ginkgo/build -S ginkgo \
- ;; esac \
- && cmake --build ginkgo/build \
- && cmake --install ginkgo/build --prefix /usr \
- && rm -rf ginkgo \
  && apt-get purge -y \
     apt-transport-https \
     apt-utils \
@@ -133,8 +99,18 @@ RUN chmod +x /bin/bash_run.sh \
        ; echo 'CUDA_GXX=g++-12' >> /etc/profile.d/ddc-cuda.sh \
  ;  fi
 
+RUN apt-get update -y \
+ && apt-get install -y --no-install-recommends file bzip2 ca-certificates g++ gcc gfortran git gzip lsb-release patch python3 tar unzip xz-utils zstd
+
 USER ci:ci
 WORKDIR /data
+
+COPY spack-env /data/spack-env
+RUN git clone --branch v1.1.1 --depth 1 https://github.com/spack/spack.git \
+ && . /data/spack/share/spack/setup-env.sh \
+ && spack env create ddc-${BACKEND} /data/spack-env/spack-${BACKEND}.yaml \
+ && spack --env ddc-${BACKEND} repo update \
+ && spack --env ddc-${BACKEND} install --fail-fast
 
 ENTRYPOINT ["/bin/bash_run.sh"]
 CMD ["/bin/bash", "-li"]

--- a/docker/latest/bash_run.sh
+++ b/docker/latest/bash_run.sh
@@ -5,5 +5,7 @@
 # SPDX-License-Identifier: MIT
 
 . /etc/profile
+. /data/spack/share/spack/setup-env.sh
+spack env activate ddc
 
 exec "$@"

--- a/docker/latest/spack-env/spack-cpu.yaml
+++ b/docker/latest/spack-env/spack-cpu.yaml
@@ -1,0 +1,50 @@
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
+---
+spack:
+  concretizer:
+    reuse: false
+    unify: true
+  packages:
+    all:
+      require:
+        - 'target=x86_64'
+        - '~cuda'
+        - '~rocm'
+        - '~openmp'
+        - '~mpi'
+        - '~fortran'
+    c:
+      require: 'gcc@13'
+    cxx:
+      require: 'gcc@13'
+    fortran:
+      require: 'gcc@13'
+    lapack:
+      require: 'openblas@0.3'
+  repos:
+    builtin:
+      tag: v2026.03.0
+  specs:
+    - 'gcc@13'
+    - 'benchmark@1.9 ~performance_counters'
+    - 'cmake@4.2'
+    - 'ginkgo@1.11'
+    - 'googletest@1.17 +gmock'
+    - 'kokkos@5.0'
+    - 'kokkos-fft@1.0 host_backend=fftw-serial'
+    - 'kokkos-kernels@5.0'
+    - 'lapack'
+    - 'paraconf@1.0'
+    - 'pkgconfig'
+    - 'pdi@1.10.1:1.10'
+    - 'pdiplugin-decl-hdf5@1.10.1:1.10'
+    - 'pdiplugin-user-code@1.10.1:1.10'
+    - 'pdiplugin-trace@1.10.1:1.10'
+    - 'py-gcovr@8.6'
+  view:
+    default:
+      root: .spack-env/view
+      exclude: ['gcc-runtime']

--- a/docker/latest/spack-env/spack-cuda.yaml
+++ b/docker/latest/spack-env/spack-cuda.yaml
@@ -1,0 +1,54 @@
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
+---
+spack:
+  concretizer:
+    reuse: false
+    unify: true
+  packages:
+    all:
+      require:
+        - 'target=x86_64'
+        - '+cuda cuda_arch=80'
+        - '~rocm'
+        - '~openmp'
+        - '~mpi'
+        - '~fortran'
+    c:
+      require: 'gcc@12'
+    cuda:
+      buildable: false
+      externals:
+        - spec: cuda@12.9
+          prefix: /usr/local/cuda-12.9
+    cxx:
+      require: 'gcc@12'
+    fortran:
+      require: 'gcc@12'
+    lapack:
+      require: 'openblas@0.3'
+  repos:
+    builtin:
+      tag: v2026.03.0
+  specs:
+    - 'gcc@12'
+    - 'benchmark@1.9 ~performance_counters'
+    - 'cmake@4.2'
+    - 'ginkgo@1.11'
+    - 'googletest@1.17 +gmock'
+    - 'kokkos@5.0 +cuda_constexpr +cuda_relocatable_device_code'
+    - 'kokkos-fft@1.0 host_backend=fftw-serial device_backend=cufft'
+    - 'kokkos-kernels@5.0'
+    - 'lapack'
+    - 'paraconf@1.0'
+    - 'pkgconfig'
+    - 'pdi@1.10.1:1.10'
+    - 'pdiplugin-decl-hdf5@1.10.1:1.10'
+    - 'pdiplugin-user-code@1.10.1:1.10'
+    - 'pdiplugin-trace@1.10.1:1.10'
+  view:
+    default:
+      root: .spack-env/view
+      exclude: ['gcc-runtime']

--- a/docker/latest/spack-env/spack-hip.yaml
+++ b/docker/latest/spack-env/spack-hip.yaml
@@ -1,0 +1,131 @@
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
+---
+spack:
+  concretizer:
+    reuse: false
+    unify: true
+  packages:
+    all:
+      require:
+        - 'target=x86_64'
+        - '~cuda'
+        - '~openmp'
+        - '~mpi'
+        - '~fortran'
+    c:
+      require: 'gcc@13'
+    comgr:
+      buildable: false
+      externals:
+        - spec: comgr@6.4.3
+          prefix: /opt/rocm-6.4.3
+    cxx:
+      require: 'gcc@13'
+    gcc:
+      externals:
+        - spec: gcc@13.3.0 languages:='c,c++,fortran'
+          prefix: /usr
+          extra_attributes:
+            compilers:
+              c: /usr/bin/gcc
+              cxx: /usr/bin/g++
+              fortran: /usr/bin/gfortran
+    fortran:
+      require: 'gcc@13'
+    hip:
+      buildable: false
+      externals:
+        - spec: hip@6.4.3
+          prefix: /opt/rocm-6.4.3
+          extra_attributes:
+            compilers:
+              c: /opt/rocm-6.4.3/llvm/bin/clang++
+              c++: /opt/rocm-6.4.3/llvm/bin/clang++
+              hip: /opt/rocm-6.4.3/bin/hipcc
+    hipblas:
+      buildable: false
+      externals:
+        - spec: hipblas@6.4.3
+          prefix: /opt/rocm-6.4.3
+    hipfft:
+      buildable: false
+      externals:
+        - prefix: /opt/rocm-6.4.3
+          spec: hipfft@6.4.3
+    hiprand:
+      buildable: false
+      externals:
+        - prefix: /opt/rocm-6.4.3
+          spec: hiprand@6.4.3
+    hipsparse:
+      buildable: false
+      externals:
+        - spec: hipsparse@6.4.3
+          prefix: /opt/rocm-6.4.3
+    hsa-rocr-dev:
+      buildable: false
+      externals:
+        - spec: hsa-rocr-dev@6.4.3
+          prefix: /opt/rocm-6.4.3
+    lapack:
+      require: 'openblas@0.3'
+    llvm-amdgpu:
+      buildable: false
+      externals:
+        - spec: llvm-amdgpu@=6.4.3
+          prefix: /opt/rocm-6.4.3/llvm
+          extra_attributes:
+            compilers:
+              c: /opt/rocm-6.4.3/llvm/bin/clang
+              cxx: /opt/rocm-6.4.3/llvm/bin/clang++
+    rocblas:
+      buildable: false
+      externals:
+        - spec: rocblas@6.4.3
+          prefix: /opt/rocm-6.4.3
+    rocprim:
+      buildable: false
+      externals:
+        - spec: rocprim@6.4.3
+          prefix: /opt/rocm-6.4.3
+    rocrand:
+      buildable: false
+      externals:
+        - prefix: /opt/rocm-6.4.3
+          spec: rocrand@6.4.3
+    rocthrust:
+      buildable: false
+      externals:
+        - prefix: /opt/rocm-6.4.3
+          spec: rocthrust@6.4.3
+    roctracer-dev:
+      buildable: false
+      externals:
+        - prefix: /opt/rocm-6.4.3
+          spec: roctracer-dev@6.4.3
+  repos:
+    builtin:
+      tag: v2026.03.0
+  specs:
+    - 'gcc@13'
+    - 'benchmark@1.9 ~performance_counters'
+    - 'cmake@4.2'
+    - 'ginkgo@1.11 +rocm amdgpu_target=gfx90a'
+    - 'googletest@1.17 +gmock'
+    - 'kokkos@5.0 +hip_relocatable_device_code +rocm amdgpu_target=gfx90a'
+    - 'kokkos-fft@1.0 host_backend=fftw-serial device_backend=hipfft'
+    - 'kokkos-kernels@5.0'
+    - 'lapack'
+    - 'paraconf@1.0'
+    - 'pkgconfig'
+    - 'pdi@1.10.1:1.10'
+    - 'pdiplugin-decl-hdf5@1.10.1:1.10'
+    - 'pdiplugin-user-code@1.10.1:1.10'
+    - 'pdiplugin-trace@1.10.1:1.10'
+  view:
+    default:
+      root: .spack-env/view
+      exclude: ['gcc-runtime']

--- a/docker/oldest/Dockerfile
+++ b/docker/oldest/Dockerfile
@@ -103,9 +103,9 @@ WORKDIR /data
 COPY spack-env /data/spack-env
 RUN git clone --branch v1.1.1 --depth 1 https://github.com/spack/spack.git \
  && . /data/spack/share/spack/setup-env.sh \
- && spack env create ddc-${BACKEND} /data/spack-env/spack-${BACKEND}.yaml \
- && spack --env ddc-${BACKEND} repo update \
- && spack --env ddc-${BACKEND} install --fail-fast
+ && spack env create ddc /data/spack-env/spack-${BACKEND}.yaml \
+ && spack --env ddc repo update \
+ && spack --env ddc install --fail-fast
 
 ENTRYPOINT ["/bin/bash_run.sh"]
 CMD ["/bin/bash", "-li"]

--- a/docker/oldest/Dockerfile
+++ b/docker/oldest/Dockerfile
@@ -8,10 +8,8 @@ LABEL "org.opencontainers.image.source"="https://github.com/CExA-project/ddc"
 
 ARG BACKEND
 ARG AMDGPU_VERSION=6.2.4
-ARG CMAKE_VERSION=3.25.3
 ARG CUDA_MAJOR_VERSION=12
 ARG CUDA_MINOR_VERSION=2
-ARG GINKGO_VERSION=1.8.0
 ARG LLVM_VERSION=16
 ARG ROCM_VERSION=6.2.4
 
@@ -20,7 +18,6 @@ ENV BASH_ENV=/etc/profile
 SHELL ["/bin/bash", "-c"]
 
 ENV PATH="/usr/local/cuda-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}/bin${PATH:+:${PATH}}"
-ENV PATH="/opt/cmake-${CMAKE_VERSION}-linux-x86_64/bin${PATH:+:${PATH}}"
 ENV PATH="${PATH:+$PATH:}/opt/rocm-${ROCM_VERSION}/bin"
 ENV CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:+$CMAKE_PREFIX_PATH:}/opt/rocm-${ROCM_VERSION}"
 
@@ -36,9 +33,7 @@ RUN chmod +x /bin/bash_run.sh \
     gpg \
     wget \
  && mkdir --parents --mode=0755 /etc/apt/keyrings \
- && wget -O /usr/share/keyrings/pdidev-archive-keyring.gpg https://repo.pdi.dev/ubuntu/pdidev-archive-keyring.gpg \
  && wget -O /usr/share/keyrings/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
- && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/pdidev-archive-keyring.gpg] https://repo.pdi.dev/ubuntu jammy main" > /etc/apt/sources.list.d/pdi.list \
  && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/apt.llvm.org.asc] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list \
  && case "x${BACKEND}" in \
     "xhip") \
@@ -52,18 +47,6 @@ RUN chmod +x /bin/bash_run.sh \
       && wget -O /etc/apt/preferences.d/cuda-repository-pin-600 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin \
  ;; esac \
  && apt-get update -y \
- && apt-get install -y --no-install-recommends \
-    build-essential \
-    git \
-    libfftw3-dev \
-    libhwloc-dev \
-    liblapacke-dev \
-    libpdi-dev \
-    pdiplugin-decl-hdf5-serial \
-    pdiplugin-trace \
-    pdiplugin-user-code \
-    pkg-config \
-    python3 \
  && case "${BACKEND}" in \
     "cpu") \
       apt-get install -y --no-install-recommends \
@@ -78,10 +61,13 @@ RUN chmod +x /bin/bash_run.sh \
       libcublas-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
       libcufft-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
       libcurand-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
+      libcusolver-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
       libcusparse-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
       libnvjitlink-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
  ;; "hip") \
       apt-get install -y --no-install-recommends \
+      # libxml2 seems to be a missing dependency of rocm-hip-runtime
+      libxml2 \
       hipblas-dev${ROCM_VERSION} \
       hipfft-dev${ROCM_VERSION} \
       hiprand-dev${ROCM_VERSION} \
@@ -93,25 +79,6 @@ RUN chmod +x /bin/bash_run.sh \
       && echo "/opt/rocm/lib64" >> /etc/ld.so.conf.d/rocm.conf \
       && ldconfig \
  ;; esac \
- && wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz \
- && tar -xvf cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz --directory /opt \
- && rm -f cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz \
- && git clone --branch v${GINKGO_VERSION} --depth 1 https://github.com/ginkgo-project/ginkgo.git \
- && case "${BACKEND}" in \
-    "cpu") \
-      cmake -DCMAKE_BUILD_TYPE=Release -DGINKGO_BUILD_OMP=ON -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF -DGINKGO_BUILD_BENCHMARKS=OFF -B ginkgo/build -S ginkgo \
- ;; "cuda") \
-      cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CUDA_HOST_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DGINKGO_CUDA_ARCHITECTURES=70 -DGINKGO_BUILD_CUDA=ON -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF -DGINKGO_BUILD_BENCHMARKS=OFF -B ginkgo/build -S ginkgo \
- ;; "hip") \
-      # HIP_PATH needs to be set to avoid Ginkgo defining it (https://github.com/ginkgo-project/ginkgo/blob/develop/cmake/hip_path.cmake).
-      # The Ginkgo <1.9 heuristic does not seem to be compatible with the new HIP v6 directory layout.
-      # This makes amdclang++ fail during cmake compiler test (https://releases.llvm.org/18.1.0/tools/clang/docs/HIPSupport.html#order-of-precedence-for-hip-path)
-      export HIP_PATH=`hipconfig --path` \
-      && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_HIP_ARCHITECTURES=gfx90a -DGINKGO_BUILD_HIP=ON -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF -DGINKGO_BUILD_BENCHMARKS=OFF -B ginkgo/build -S ginkgo \
- ;; esac \
- && cmake --build ginkgo/build \
- && cmake --install ginkgo/build --prefix /usr \
- && rm -rf ginkgo \
  && apt-get purge -y \
     apt-transport-https \
     apt-utils \
@@ -127,8 +94,18 @@ RUN chmod +x /bin/bash_run.sh \
        ; echo 'CUDA_GXX=g++' >> /etc/profile.d/ddc-cuda.sh \
  ;  fi
 
+RUN apt-get update -y \
+ && apt-get install -y --no-install-recommends file bzip2 ca-certificates g++ gcc gfortran git gzip lsb-release patch python3 tar unzip xz-utils zstd
+
 USER ci:ci
 WORKDIR /data
+
+COPY spack-env /data/spack-env
+RUN git clone --branch v1.1.1 --depth 1 https://github.com/spack/spack.git \
+ && . /data/spack/share/spack/setup-env.sh \
+ && spack env create ddc-${BACKEND} /data/spack-env/spack-${BACKEND}.yaml \
+ && spack --env ddc-${BACKEND} repo update \
+ && spack --env ddc-${BACKEND} install --fail-fast
 
 ENTRYPOINT ["/bin/bash_run.sh"]
 CMD ["/bin/bash", "-li"]

--- a/docker/oldest/bash_run.sh
+++ b/docker/oldest/bash_run.sh
@@ -5,5 +5,7 @@
 # SPDX-License-Identifier: MIT
 
 . /etc/profile
+. /data/spack/share/spack/setup-env.sh
+spack env activate ddc
 
 exec "$@"

--- a/docker/oldest/spack-env/spack-cpu.yaml
+++ b/docker/oldest/spack-env/spack-cpu.yaml
@@ -1,0 +1,49 @@
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
+---
+spack:
+  concretizer:
+    reuse: false
+    unify: true
+  packages:
+    all:
+      require:
+        - 'target=x86_64'
+        - '~cuda'
+        - '~rocm'
+        - '~openmp'
+        - '~mpi'
+        - '~fortran'
+    c:
+      require: 'gcc@11'
+    cxx:
+      require: 'gcc@11'
+    fortran:
+      require: 'gcc@11'
+    lapack:
+      require: 'openblas@0.3'
+  repos:
+    builtin:
+      tag: v2026.03.0
+  specs:
+    - 'gcc@11'
+    - 'benchmark@1.9 ~performance_counters'
+    - 'cmake@3.25'
+    - 'ginkgo@1.8'
+    - 'googletest@1.14 +gmock'
+    - 'kokkos@4.7'
+    - 'kokkos-fft@0.3 host_backend=fftw-serial'
+    - 'kokkos-kernels@4.7'
+    - 'lapack'
+    - 'paraconf@1.0'
+    - 'pkgconfig'
+    - 'pdi@1.10.1:1.10'
+    - 'pdiplugin-decl-hdf5@1.10.1:1.10'
+    - 'pdiplugin-user-code@1.10.1:1.10'
+    - 'pdiplugin-trace@1.10.1:1.10'
+  view:
+    default:
+      root: .spack-env/view
+      exclude: ['gcc-runtime']

--- a/docker/oldest/spack-env/spack-cuda.yaml
+++ b/docker/oldest/spack-env/spack-cuda.yaml
@@ -1,0 +1,54 @@
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
+---
+spack:
+  concretizer:
+    reuse: false
+    unify: true
+  packages:
+    all:
+      require:
+        - 'target=x86_64'
+        - '+cuda cuda_arch=80'
+        - '~rocm'
+        - '~openmp'
+        - '~mpi'
+        - '~fortran'
+    c:
+      require: 'gcc@11'
+    cuda:
+      buildable: false
+      externals:
+        - spec: cuda@12.2
+          prefix: /usr/local/cuda-12.2
+    cxx:
+      require: 'gcc@11'
+    fortran:
+      require: 'gcc@11'
+    lapack:
+      require: 'openblas@0.3'
+  repos:
+    builtin:
+      tag: v2026.03.0
+  specs:
+    - 'gcc@11'
+    - 'benchmark@1.9 ~performance_counters'
+    - 'cmake@3.25'
+    - 'ginkgo@1.8'
+    - 'googletest@1.14 +gmock'
+    - 'kokkos@4.7 +cuda_constexpr +cuda_relocatable_device_code'
+    - 'kokkos-fft@0.3 host_backend=fftw-serial device_backend=cufft'
+    - 'kokkos-kernels@4.7'
+    - 'lapack'
+    - 'paraconf@1.0'
+    - 'pkgconfig'
+    - 'pdi@1.10.1:1.10'
+    - 'pdiplugin-decl-hdf5@1.10.1:1.10'
+    - 'pdiplugin-user-code@1.10.1:1.10'
+    - 'pdiplugin-trace@1.10.1:1.10'
+  view:
+    default:
+      root: .spack-env/view
+      exclude: ['gcc-runtime']

--- a/docker/oldest/spack-env/spack-hip.yaml
+++ b/docker/oldest/spack-env/spack-hip.yaml
@@ -1,0 +1,131 @@
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
+---
+spack:
+  concretizer:
+    reuse: false
+    unify: true
+  packages:
+    all:
+      require:
+        - 'target=x86_64'
+        - '~cuda'
+        - '~openmp'
+        - '~mpi'
+        - '~fortran'
+    c:
+      require: 'gcc@11'
+    comgr:
+      buildable: false
+      externals:
+        - spec: comgr@6.2.4
+          prefix: /opt/rocm-6.2.4
+    cxx:
+      require: 'gcc@11'
+    gcc:
+      externals:
+        - spec: gcc@11.3.0 languages:='c,c++,fortran'
+          prefix: /usr
+          extra_attributes:
+            compilers:
+              c: /usr/bin/gcc
+              cxx: /usr/bin/g++
+              fortran: /usr/bin/gfortran
+    fortran:
+      require: 'gcc@11'
+    hip:
+      buildable: false
+      externals:
+        - spec: hip@6.2.4
+          prefix: /opt/rocm-6.2.4
+          extra_attributes:
+            compilers:
+              c: /opt/rocm-6.2.4/llvm/bin/clang++
+              c++: /opt/rocm-6.2.4/llvm/bin/clang++
+              hip: /opt/rocm-6.2.46.2.4/bin/hipcc
+    hipblas:
+      buildable: false
+      externals:
+        - spec: hipblas@6.2.4
+          prefix: /opt/rocm-6.2.4
+    hipfft:
+      buildable: false
+      externals:
+        - prefix: /opt/rocm-6.2.4
+          spec: hipfft@6.2.4
+    hiprand:
+      buildable: false
+      externals:
+        - prefix: /opt/rocm-6.2.4
+          spec: hiprand@6.2.4
+    hipsparse:
+      buildable: false
+      externals:
+        - spec: hipsparse@6.2.4
+          prefix: /opt/rocm-6.2.4
+    hsa-rocr-dev:
+      buildable: false
+      externals:
+        - spec: hsa-rocr-dev@6.2.4
+          prefix: /opt/rocm-6.2.4
+    lapack:
+      require: 'openblas@0.3'
+    llvm-amdgpu:
+      buildable: false
+      externals:
+        - spec: llvm-amdgpu@=6.2.4
+          prefix: /opt/rocm-6.2.4/llvm
+          extra_attributes:
+            compilers:
+              c: /opt/rocm-6.2.4/llvm/bin/clang
+              cxx: /opt/rocm-6.2.4/llvm/bin/clang++
+    rocblas:
+      buildable: false
+      externals:
+        - spec: rocblas@6.2.4
+          prefix: /opt/rocm-6.2.4
+    rocprim:
+      buildable: false
+      externals:
+        - spec: rocprim@6.2.4
+          prefix: /opt/rocm-6.2.4
+    rocrand:
+      buildable: false
+      externals:
+        - prefix: /opt/rocm-6.2.4
+          spec: rocrand@6.2.4
+    rocthrust:
+      buildable: false
+      externals:
+        - prefix: /opt/rocm-6.2.4
+          spec: rocthrust@6.2.4
+    roctracer-dev:
+      buildable: false
+      externals:
+        - prefix: /opt/rocm-6.2.4
+          spec: roctracer-dev@6.2.4
+  repos:
+    builtin:
+      tag: v2026.03.0
+  specs:
+    - 'gcc@11'
+    - 'benchmark@1.9 ~performance_counters'
+    - 'cmake@3.25'
+    - 'ginkgo@1.8 +rocm amdgpu_target=gfx90a'
+    - 'googletest@1.14 +gmock'
+    - 'kokkos@4.7 +hip_relocatable_device_code +rocm amdgpu_target=gfx90a'
+    - 'kokkos-fft@0.3 host_backend=fftw-serial device_backend=hipfft'
+    - 'kokkos-kernels@4.7'
+    - 'lapack'
+    - 'paraconf@1.0'
+    - 'pkgconfig'
+    - 'pdi@1.10.1:1.10'
+    - 'pdiplugin-decl-hdf5@1.10.1:1.10'
+    - 'pdiplugin-user-code@1.10.1:1.10'
+    - 'pdiplugin-trace@1.10.1:1.10'
+  view:
+    default:
+      root: .spack-env/view
+      exclude: ['gcc-runtime']


### PR DESCRIPTION
This PR finally makes all dependencies pre-installed in the Ubuntu workflow. This allows:
- to fix the issue with PDI 1.11.0 encountered in #1087 
- to parallelize the clang-tidy job