### PR TITLE
Implement experimental batched parallel_transform_reduce

### DIFF
--- a/src/ddc/parallel_transform_reduce.hpp
+++ b/src/ddc/parallel_transform_reduce.hpp
@@ -11,6 +11,7 @@
 
 #include <Kokkos_Core.hpp>
 
+#include "chunk_traits.hpp"
 #include "ddc_to_kokkos_execution_policy.hpp"
 #include "discrete_vector.hpp"
 #include "reducer.hpp"
@@ -19,74 +20,74 @@ namespace ddc {
 
 namespace detail {
 
-template <class Reducer>
+template <class Reducer, class MemorySpace>
 struct DdcToKokkosReducer
 {
 };
 
-template <class T>
-struct DdcToKokkosReducer<reducer::sum<T>>
+template <class T, class MemorySpace>
+struct DdcToKokkosReducer<reducer::sum<T>, MemorySpace>
 {
-    using type = Kokkos::Sum<T>;
+    using type = Kokkos::Sum<T, MemorySpace>;
 };
 
-template <class T>
-struct DdcToKokkosReducer<reducer::prod<T>>
+template <class T, class MemorySpace>
+struct DdcToKokkosReducer<reducer::prod<T>, MemorySpace>
 {
-    using type = Kokkos::Prod<T>;
+    using type = Kokkos::Prod<T, MemorySpace>;
 };
 
-template <class T>
-struct DdcToKokkosReducer<reducer::land<T>>
+template <class T, class MemorySpace>
+struct DdcToKokkosReducer<reducer::land<T>, MemorySpace>
 {
-    using type = Kokkos::LAnd<T>;
+    using type = Kokkos::LAnd<T, MemorySpace>;
 };
 
-template <class T>
-struct DdcToKokkosReducer<reducer::lor<T>>
+template <class T, class MemorySpace>
+struct DdcToKokkosReducer<reducer::lor<T>, MemorySpace>
 {
-    using type = Kokkos::LOr<T>;
+    using type = Kokkos::LOr<T, MemorySpace>;
 };
 
-template <class T>
-struct DdcToKokkosReducer<reducer::band<T>>
+template <class T, class MemorySpace>
+struct DdcToKokkosReducer<reducer::band<T>, MemorySpace>
 {
-    using type = Kokkos::BAnd<T>;
+    using type = Kokkos::BAnd<T, MemorySpace>;
 };
 
-template <class T>
-struct DdcToKokkosReducer<reducer::bor<T>>
+template <class T, class MemorySpace>
+struct DdcToKokkosReducer<reducer::bor<T>, MemorySpace>
 {
-    using type = Kokkos::BOr<T>;
+    using type = Kokkos::BOr<T, MemorySpace>;
 };
 
-template <class T>
-struct DdcToKokkosReducer<reducer::bxor<T>>
+template <class T, class MemorySpace>
+struct DdcToKokkosReducer<reducer::bxor<T>, MemorySpace>
 {
     static_assert(std::is_same_v<T, T>, "This reducer is not yet implemented");
 };
 
-template <class T>
-struct DdcToKokkosReducer<reducer::min<T>>
+template <class T, class MemorySpace>
+struct DdcToKokkosReducer<reducer::min<T>, MemorySpace>
 {
-    using type = Kokkos::Min<T>;
+    using type = Kokkos::Min<T, MemorySpace>;
 };
 
-template <class T>
-struct DdcToKokkosReducer<reducer::max<T>>
+template <class T, class MemorySpace>
+struct DdcToKokkosReducer<reducer::max<T>, MemorySpace>
 {
-    using type = Kokkos::Max<T>;
+    using type = Kokkos::Max<T, MemorySpace>;
 };
 
-template <class T>
-struct DdcToKokkosReducer<reducer::minmax<T>>
+template <class T, class MemorySpace>
+struct DdcToKokkosReducer<reducer::minmax<T>, MemorySpace>
 {
-    using type = Kokkos::MinMax<T>;
+    using type = Kokkos::MinMax<T, MemorySpace>;
 };
 
 /// Alias template to transform a DDC reducer type to a Kokkos reducer type
-template <class Reducer>
-using ddc_to_kokkos_reducer_t = DdcToKokkosReducer<Reducer>::type;
+template <class Reducer, class MemorySpace = Kokkos::HostSpace>
+using ddc_to_kokkos_reducer_t = DdcToKokkosReducer<Reducer, MemorySpace>::type;
 
 template <class Reducer, class Functor, class Support, class IndexSequence>
 class TransformReducerKokkosLambdaAdapter
@@ -264,5 +265,134 @@ T parallel_transform_reduce(
             std::forward<BinaryReductionOp>(reduce),
             std::forward<UnaryTransformOp>(transform));
 }
+
+namespace experimental {
+
+namespace detail {
+
+template <class Reducer, class Functor, class Support, class DElem, class IndexSequence>
+class TransformReducerChunkKokkosLambdaAdapter
+{
+};
+
+template <class Reducer, class Functor, class Support, class DElem, std::size_t... Idx>
+class TransformReducerChunkKokkosLambdaAdapter<
+        Reducer,
+        Functor,
+        Support,
+        DElem,
+        std::index_sequence<Idx...>>
+{
+    template <std::size_t I>
+    using index_type = DiscreteVectorElement;
+
+    Reducer m_reducer;
+
+    Functor m_functor;
+
+    Support m_support;
+
+    DElem m_delem;
+
+public:
+    TransformReducerChunkKokkosLambdaAdapter(
+            Reducer const& r,
+            Functor const& f,
+            Support const& support,
+            DElem const& delem)
+        : m_reducer(r)
+        , m_functor(f)
+        , m_support(support)
+        , m_delem(delem)
+    {
+    }
+
+    KOKKOS_FUNCTION void operator()(
+            [[maybe_unused]] index_type<0> unused_id,
+            Reducer::value_type& a) const
+        requires(sizeof...(Idx) == 0)
+    {
+        a = m_reducer(a, m_functor(m_delem, m_support(typename Support::discrete_vector_type())));
+    }
+
+    KOKKOS_FUNCTION void operator()(index_type<Idx>... ids, Reducer::value_type& a) const
+        requires(sizeof...(Idx) > 0)
+    {
+        a = m_reducer(
+                a,
+                m_functor(m_delem, m_support(typename Support::discrete_vector_type(ids...))));
+    }
+};
+
+template <class Reducer, class Functor, class Support, class DElem, std::size_t... Idx>
+TransformReducerChunkKokkosLambdaAdapter(
+        Reducer const& r,
+        Functor const& f,
+        Support const& support,
+        DElem const& delem)
+        -> TransformReducerChunkKokkosLambdaAdapter<
+                Reducer,
+                Functor,
+                Support,
+                DElem,
+                std::make_index_sequence<Support::rank()>>;
+
+} // namespace detail
+
+/** Performs a parallel transform-reduce over an nD domain using a Kokkos execution space.
+ *
+ * For each element of `out`, a reduction is performed over the dimensions of
+ * `domain` that are not present in `out.domain()`. The reduction combines the
+ * values obtained by applying `transform` to each element of the corresponding
+ * subdomain.
+ *
+ * @param[in] label name used to identify the Kokkos kernel.
+ * @param[in] execution_space Kokkos execution space on which the reductions are executed.
+ * @param[in] domain full domain over which the transform-reduce is defined.
+ * @param[out] out chunk receiving the reduction result for each point of
+ *                 `out.domain()`. Its domain must be a subdomain of `domain`.
+ * @param[in] reduce binary reduction operator used to combine transformed values.
+ *                   It must be compatible with the value type stored in `out`.
+ * @param[in] transform unary function applied to each element of the reduction
+ *                      subdomain. Its return type must be accepted by `reduce`.
+ */
+template <
+        class ExecSpace,
+        class Support,
+        class ChunkDst,
+        class BinaryReductionOp,
+        class UnaryTransformOp>
+void parallel_transform_reduce(
+        std::string const& label,
+        ExecSpace const& execution_space,
+        Support const& domain,
+        ChunkDst&& out,
+        BinaryReductionOp const& reduce,
+        UnaryTransformOp const& transform) noexcept
+    requires(ddc::is_borrowed_chunk_v<ChunkDst>)
+{
+    using DDomOut = std::remove_cvref_t<ChunkDst>::discrete_domain_type;
+    using DElemOut = DDomOut::discrete_element_type;
+    using MemorySpaceOut = std::remove_cvref_t<ChunkDst>::memory_space;
+    assert(out.domain() == DDomOut(domain));
+
+    auto ddom_interest = remove_dims_of(domain, out.domain());
+    host_for_each(out.domain(), [&](DElemOut iout) {
+        Kokkos::parallel_reduce(
+                label,
+                ddc::detail::ddc_to_kokkos_execution_policy(
+                        execution_space,
+                        ddc::detail::array(ddom_interest.extents())),
+                detail::TransformReducerChunkKokkosLambdaAdapter(
+                        reduce,
+                        transform,
+                        ddom_interest,
+                        iout),
+                ddc::detail::ddc_to_kokkos_reducer_t<BinaryReductionOp, MemorySpaceOut>(
+                        out[iout].allocation_kokkos_view()));
+    });
+}
+
+} // namespace experimental
 
 } // namespace ddc

--- a/tests/parallel_transform_reduce.cpp
+++ b/tests/parallel_transform_reduce.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include <Kokkos_Core.hpp>
+#include <Kokkos_StdAlgorithms.hpp>
 
 inline namespace anonymous_namespace_workaround_parallel_transform_reduce_cpp {
 
@@ -126,4 +127,62 @@ TEST(ParallelTransformReduceDevice, TwoDimensions)
     int const sum
             = ddc::parallel_transform_reduce(dom, 0, ddc::reducer::sum<int>(), view.span_cview());
     EXPECT_EQ(sum, dom.size());
+}
+
+TEST(ParallelTransformReduceDevice, SumXY2Scalar)
+{
+    Kokkos::DefaultExecutionSpace const exec_space;
+
+    DDom0D const dom_0d;
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
+
+    Kokkos::View<int> const storage(Kokkos::view_alloc("storage", exec_space));
+    ddc::ChunkSpan const chunk_0d(storage, dom_0d);
+    ddc::parallel_fill(exec_space, chunk_0d, -1);
+
+    ddc::Chunk chunk_x_y(dom_x_y, ddc::DeviceAllocator<int>());
+    ddc::parallel_fill(exec_space, chunk_x_y, 1);
+
+    ddc::experimental::parallel_transform_reduce(
+            "xy2scalar",
+            exec_space,
+            chunk_x_y.domain(),
+            chunk_0d,
+            ddc::reducer::sum<int>(),
+            chunk_x_y.span_cview());
+
+    int const res = ddc::parallel_transform_reduce(
+            "xy2scalar",
+            exec_space,
+            chunk_x_y.domain(),
+            0,
+            ddc::reducer::sum<int>(),
+            chunk_x_y.span_cview());
+
+    EXPECT_EQ(res, dom_x_y.size());
+}
+
+TEST(ParallelTransformReduceDevice, SumXY2X)
+{
+    Kokkos::DefaultExecutionSpace const exec_space;
+
+    DDomX const dom_x(lbound_x, nelems_x);
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
+
+    Kokkos::View<int*> const storage(Kokkos::view_alloc("storage", exec_space), dom_x.size());
+    ddc::ChunkSpan const chunk_x(storage, dom_x);
+    ddc::parallel_fill(exec_space, chunk_x, -1);
+
+    ddc::Chunk chunk_x_y(dom_x_y, ddc::DeviceAllocator<int>());
+    ddc::parallel_fill(exec_space, chunk_x_y, 1);
+
+    ddc::experimental::parallel_transform_reduce(
+            "xy2x",
+            exec_space,
+            chunk_x_y.domain(),
+            chunk_x,
+            ddc::reducer::sum<int>(),
+            chunk_x_y.span_cview());
+
+    EXPECT_EQ(Kokkos::Experimental::count(exec_space, storage, 12), dom_x.size());
 }


### PR DESCRIPTION
This PR implements an experimental extension of parallel_transform_reduce that allows a user to do partial reductions (or batched reductions).

The user must pass a functor that accepts two `ddc::DiscreteElement`:
- `ib`: identifying the entry of the output array,
- `io`: identifying the rest of the dimensions given by the input `domain`,

and that returns a value that contributes to the reduction in `out[ib]`.

Note a ChunkSpan satisfies this criterion and therefore allows to do partial reductions from an input ChunkSpan. 