### PR TITLE
Extend save_npy to layout stride and device memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ To use DDC core, one needs the following dependencies:
 * (optional, micro benchmarking) Benchmark 1.8...<2
 * (optional, documentation) Doxygen 1.9.8...<2
 * (optional, unit-testing) GoogleTest 1.14...<2
+* (optional, unit-testing) NumPy 1.24...<3
+* (optional, unit-testing) pytest 8.4...<10
 
 To use DDC components, one needs the following dependencies:
 

--- a/src/ddc/save_npy.hpp
+++ b/src/ddc/save_npy.hpp
@@ -15,6 +15,9 @@
 
 #include <Kokkos_Core.hpp>
 
+#include "chunk_span.hpp"
+#include "create_mirror.hpp"
+
 namespace ddc::detail {
 
 enum class NpyByteOrder : char { little_endian = '<', big_endian = '>', not_applicable = '|' };
@@ -110,45 +113,40 @@ void save_npy(std::filesystem::path const& filename, NpyArrayView const& view);
 namespace ddc::experimental {
 
 /**
- * @brief Save a contiguous mdspan in the NumPy format in a stream.
- *
- * Supports Kokkos::layout_left and Kokkos::layout_right layouts with
- * host-accessible default accessors.
+ * @brief Save a ddc::ChunkSpan in the NumPy format in a stream.
  *
  * @param os Output stream receiving the .npy data.
- * @param mds mdspan to serialize.
+ * @param chunk_span ChunkSpan to serialize.
  */
-template <typename T, typename Extents, typename Layout, typename Accessor>
-void save_npy(std::ostream& os, Kokkos::mdspan<T, Extents, Layout, Accessor> const& mds)
+template <typename T, typename SupportType, typename LayoutStridedPolicy, typename MemorySpace>
+void save_npy(
+        std::ostream& os,
+        ChunkSpan<T, SupportType, LayoutStridedPolicy, MemorySpace> const& chunk_span)
 {
-    static_assert(
-            std::is_same_v<Layout, Kokkos::layout_left>
-                    || std::is_same_v<Layout, Kokkos::layout_right>,
-            "save_npy: only contiguous layouts supported.");
-
-    ddc::detail::save_npy(os, ddc::detail::to_np_array_view(mds));
+    auto chunk_span_right = ::ddc::detail::create_layout_right_view_and_copy(chunk_span);
+    auto chunk_span_right_host
+            = create_mirror_view_and_copy(Kokkos::HostSpace(), chunk_span_right.span_view());
+    ddc::detail::
+            save_npy(os, ddc::detail::to_np_array_view(chunk_span_right_host.allocation_mdspan()));
 }
 
 /**
- * @brief Save a contiguous mdspan in the NumPy format in a file.
- *
- * Supports Kokkos::layout_left and Kokkos::layout_right layouts with
- * host-accessible default accessors.
+ * @brief Save a ddc::ChunkSpan in the NumPy format in a file.
  *
  * @param filename Path to the output .npy file.
- * @param mds mdspan to serialize.
+ * @param chunk_span ChunkSpan to serialize.
  */
-template <typename T, typename Extents, typename Layout, typename Accessor>
+template <typename T, typename SupportType, typename LayoutStridedPolicy, typename MemorySpace>
 void save_npy(
         std::filesystem::path const& filename,
-        Kokkos::mdspan<T, Extents, Layout, Accessor> const& mds)
+        ChunkSpan<T, SupportType, LayoutStridedPolicy, MemorySpace> const& chunk_span)
 {
-    static_assert(
-            std::is_same_v<Layout, Kokkos::layout_left>
-                    || std::is_same_v<Layout, Kokkos::layout_right>,
-            "save_npy: only contiguous layouts supported.");
-
-    ddc::detail::save_npy(filename, ddc::detail::to_np_array_view(mds));
+    auto chunk_span_right = ::ddc::detail::create_layout_right_view_and_copy(chunk_span);
+    auto chunk_span_right_host
+            = create_mirror_view_and_copy(Kokkos::HostSpace(), chunk_span_right.span_view());
+    ddc::detail::save_npy(
+            filename,
+            ddc::detail::to_np_array_view(chunk_span_right_host.allocation_mdspan()));
 }
 
 } // namespace ddc::experimental

--- a/tests/save_npy/generate_npy_fixtures.cpp
+++ b/tests/save_npy/generate_npy_fixtures.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <array>
 #include <cmath>
 #include <complex>
 #include <cstdint>
@@ -13,10 +12,46 @@
 
 #include <Kokkos_Core.hpp>
 
+struct DDimX
+{
+};
+using DElemX = ddc::DiscreteElement<DDimX>;
+using DVectX = ddc::DiscreteVector<DDimX>;
+using DDomX = ddc::DiscreteDomain<DDimX>;
+
+
+struct DDimY
+{
+};
+using DElemY = ddc::DiscreteElement<DDimY>;
+using DVectY = ddc::DiscreteVector<DDimY>;
+using DDomY = ddc::DiscreteDomain<DDimY>;
+
+
+struct DDimZ
+{
+};
+using DElemZ = ddc::DiscreteElement<DDimZ>;
+using DVectZ = ddc::DiscreteVector<DDimZ>;
+using DDomZ = ddc::DiscreteDomain<DDimZ>;
+
+using DElemXYZ = ddc::DiscreteElement<DDimX, DDimY, DDimZ>;
+using DVectXYZ = ddc::DiscreteVector<DDimX, DDimY, DDimZ>;
+using DDomXYZ = ddc::DiscreteDomain<DDimX, DDimY, DDimZ>;
+
 namespace {
 
-std::array constexpr ns {2, 3, 4};
-int constexpr n = ns[0] * ns[1] * ns[2];
+DElemX constexpr lbound_x = ddc::init_trivial_half_bounded_space<DDimX>();
+DVectX constexpr nelems_x(2);
+
+DElemY constexpr lbound_y = ddc::init_trivial_half_bounded_space<DDimY>();
+DVectY constexpr nelems_y(3);
+
+DElemZ constexpr lbound_z = ddc::init_trivial_half_bounded_space<DDimZ>();
+DVectZ constexpr nelems_z(4);
+
+DElemXYZ constexpr lbound_x_y_z(lbound_x, lbound_y, lbound_z);
+DVectXYZ constexpr nelems_x_y_z(nelems_x, nelems_y, nelems_z);
 
 template <typename T>
 constexpr T make_value()
@@ -38,31 +73,41 @@ constexpr T make_value()
 template <typename T>
 void save_array_0d(std::filesystem::path const& path, T value)
 {
-    Kokkos::View<T, Kokkos::HostSpace> const alloc("");
-    Kokkos::deep_copy(alloc, value);
-    Kokkos::mdspan const view(alloc.data());
+    ddc::DiscreteDomain<> const dom;
+    ddc::Chunk chk(dom, ddc::DeviceAllocator<T>());
+    ddc::parallel_fill(chk, value);
 
-    ddc::experimental::save_npy(path, view);
+    ddc::experimental::save_npy(path, chk.span_cview());
 }
 
 template <typename T>
 void save_array_1d(std::filesystem::path const& path, T value)
 {
-    Kokkos::View<T*, Kokkos::HostSpace> const alloc("", n);
-    Kokkos::deep_copy(alloc, value);
-    Kokkos::mdspan const view(alloc.data(), n);
+    DDomX const dom(lbound_x, nelems_x);
+    ddc::Chunk chk(dom, ddc::DeviceAllocator<T>());
+    ddc::parallel_fill(chk, value);
 
-    ddc::experimental::save_npy(path, view);
+    ddc::experimental::save_npy(path, chk.span_cview());
+}
+
+template <typename T>
+void save_array_2d_slice(std::filesystem::path const& path, T value)
+{
+    DDomXYZ const dom(lbound_x_y_z, nelems_x_y_z);
+    ddc::Chunk chk(dom, ddc::DeviceAllocator<T>());
+    ddc::parallel_fill(chk, value);
+
+    ddc::experimental::save_npy(path, chk[DVectY(2)].span_cview());
 }
 
 template <typename T>
 void save_array_3d(std::filesystem::path const& path, T value)
 {
-    Kokkos::View<T*, Kokkos::HostSpace> const alloc("", n);
-    Kokkos::deep_copy(alloc, value);
-    Kokkos::mdspan const view(alloc.data(), ns);
+    DDomXYZ const dom(lbound_x_y_z, nelems_x_y_z);
+    ddc::Chunk chk(dom, ddc::DeviceAllocator<T>());
+    ddc::parallel_fill(chk, value);
 
-    ddc::experimental::save_npy(path, view);
+    ddc::experimental::save_npy(path, chk.span_cview());
 }
 
 } // namespace
@@ -75,6 +120,8 @@ int main(int argc, char** argv)
     save_array_0d("./float_0d.npy", make_value<float>());
 
     save_array_1d("./double_1d.npy", make_value<double>());
+
+    save_array_2d_slice("./double_2d.npy", make_value<double>());
 
     save_array_3d("./int8_3d.npy", make_value<std::int8_t>());
     save_array_3d("./int16_3d.npy", make_value<std::int16_t>());

--- a/tests/save_npy/test_npy_fixtures.py
+++ b/tests/save_npy/test_npy_fixtures.py
@@ -23,8 +23,13 @@ def gen_array_0d(dtype):
 
 
 def gen_array_1d(dtype):
-    """Generate a 1D NumPy array of length 24 filled with a dtype-specific value."""
-    return np.full(shape=(2 * 3 * 4), fill_value=gen_value(dtype), order="C")
+    """Generate a 1D NumPy array of length 2 filled with a dtype-specific value."""
+    return np.full(shape=(2), fill_value=gen_value(dtype), order="C")
+
+
+def gen_array_2d(dtype):
+    """Generate a 2D NumPy array (2x4) filled with a dtype-specific value."""
+    return np.full(shape=(2, 4), fill_value=gen_value(dtype), order="C")
 
 
 def gen_array_3d(dtype):
@@ -40,6 +45,11 @@ def test_0d():
 def test_1d():
     """Test loading and equality of a 1D float64 array."""
     np.testing.assert_array_equal(np.load("double_1d.npy"), gen_array_1d(np.float64), strict=True)
+
+
+def test_2d():
+    """Test loading and equality of a 2D float64 array."""
+    np.testing.assert_array_equal(np.load("double_2d.npy"), gen_array_2d(np.float64), strict=True)
 
 
 def test_3d():


### PR DESCRIPTION
`save_npy` now takes a `ChunkSpan` instead of `mdspan`. We now support device memory and layout stride by first making the span contiguous, if necessary, and copying the data to the host, if necessary.

Tests now use device memory and a layout stride test has been added.

The readme is updated to include new dependencies.