### PR TITLE
Fix spline evaluator

### DIFF
--- a/src/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -449,7 +449,7 @@ public:
                         for (auto const i2 : evaluation_domain2) {
                             ddc::Coordinate<continuous_dimension_type1, continuous_dimension_type2>
                                     coord_eval_2D(ddc::coordinate(i1), ddc::coordinate(i2));
-                            spline_eval_2D(i1, i2) = eval(coord_eval_2D(i1, i2), spline_coef_2D);
+                            spline_eval_2D(i1, i2) = eval(coord_eval_2D, spline_coef_2D);
                         }
                     }
                 });

--- a/src/ddc/kernels/splines/spline_evaluator_3d.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator_3d.hpp
@@ -564,7 +564,7 @@ public:
                                                 ddc::coordinate(i2),
                                                 ddc::coordinate(i3));
                                 spline_eval_3D(i1, i2, i3)
-                                        = eval(coord_eval_3D(i1, i2, i3), spline_coef_3D);
+                                        = eval(coord_eval_3D, spline_coef_3D);
                             }
                         }
                     }

--- a/src/ddc/kernels/splines/spline_evaluator_3d.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator_3d.hpp
@@ -563,8 +563,7 @@ public:
                                                 ddc::coordinate(i1),
                                                 ddc::coordinate(i2),
                                                 ddc::coordinate(i3));
-                                spline_eval_3D(i1, i2, i3)
-                                        = eval(coord_eval_3D, spline_coef_3D);
+                                spline_eval_3D(i1, i2, i3) = eval(coord_eval_3D, spline_coef_3D);
                             }
                         }
                     }

--- a/src/ddc/kernels/splines/spline_evaluator_nd.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator_nd.hpp
@@ -422,7 +422,7 @@ public:
                             [&](evaluation_domain_type::discrete_element_type const i) {
                                 ddc::Coordinate<typename BSplines::continuous_dimension_type...>
                                         coord_eval_ND(ddc::coordinate(i));
-                                spline_eval_ND(i) = eval(coord_eval_3D(i), spline_coef_ND);
+                                spline_eval_ND(i) = eval(coord_eval_ND, spline_coef_ND);
                             });
                 });
     }


### PR DESCRIPTION
Fix spline evaluator call to `operator()(spline_eval, spline_coef)` for ND evaluators (N>1). When the coefficients are not passed they are deduced on the fly. This local coordinate cannot be indexed.

Note that none of these operators seem to appear in the tests.