### PR TITLE
Fix: Safely return max() for missing tags in TypeSeq

### DIFF
--- a/src/ddc/detail/type_seq.hpp
+++ b/src/ddc/detail/type_seq.hpp
@@ -49,7 +49,8 @@ struct TypeSeqRank<SingleType<QueryTag>, TypeSeq<TagsHead, TagsTail...>>
     static constexpr bool present
             = TypeSeqRank<SingleType<QueryTag>, TypeSeq<TagsTail...>>::present;
     static constexpr std::size_t val
-            = 1 + TypeSeqRank<SingleType<QueryTag>, TypeSeq<TagsTail...>>::val;
+            = present ? 1 + TypeSeqRank<SingleType<QueryTag>, TypeSeq<TagsTail...>>::val
+                      : std::numeric_limits<std::size_t>::max();
 };
 
 template <class... QueryTags, class... Tags>

--- a/tests/type_seq.cpp
+++ b/tests/type_seq.cpp
@@ -48,6 +48,8 @@ TEST(TypeSeqTest, Rank)
     EXPECT_EQ((ddc::type_seq_rank_v<T0, A>), 0);
     EXPECT_EQ((ddc::type_seq_rank_v<T1, A>), 1);
     EXPECT_EQ((ddc::type_seq_rank_v<T2, A>), 2);
+    constexpr std::size_t max_val = std::numeric_limits<std::size_t>::max();
+    EXPECT_EQ((ddc::type_seq_rank_v<T3, A>), max_val);
 }
 
 TEST(TypeSeqTest, Element)

--- a/tests/type_seq.cpp
+++ b/tests/type_seq.cpp
@@ -48,8 +48,7 @@ TEST(TypeSeqTest, Rank)
     EXPECT_EQ((ddc::type_seq_rank_v<T0, A>), 0);
     EXPECT_EQ((ddc::type_seq_rank_v<T1, A>), 1);
     EXPECT_EQ((ddc::type_seq_rank_v<T2, A>), 2);
-    constexpr std::size_t max_val = std::numeric_limits<std::size_t>::max();
-    EXPECT_EQ((ddc::type_seq_rank_v<T3, A>), max_val);
+    EXPECT_EQ((ddc::type_seq_rank_v<T3, A>), (std::numeric_limits<std::size_t>::max()));
 }
 
 TEST(TypeSeqTest, Element)


### PR DESCRIPTION
If i use 
```bash
    struct DimX
    {
        static constexpr bool PERIODIC = true;
    };
    struct DimY
    {
        static constexpr bool PERIODIC = true;
    };
    struct DimZ {
        static constexpr bool PERIODIC = true;
    };
    struct DimW {};
    using SeqXY = ddc::detail::TypeSeq<DimX,DimY>;
    auto rank_size_3 = ddc::type_seq_rank_v<DimW,SeqXY>;
    std::cout<<rank_size_3<<std::endl;
```

Result i got:

```bash
1
```