### PR TITLE
Update Spack environments

### DIFF
--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -68,20 +68,23 @@ jobs:
       - name: Set up Spack
         uses: spack/setup-spack@16b756799ede8b28951287f89bcd3fdb32ec1ca3  # v3.0.0
         with:
-          spack_ref: v1.1.1
+          spack_ref: v1.2.0
           buildcache: true
       - name: Install
         shell: spack-bash {0}
         run: |
           spack env create . spack-env/spack-${{matrix.os}}.yaml
-          spack --env . repo update
-          spack --env . install
+          spack env activate .
+          spack repo update
+          spack install
       - name: Push packages and update index
         shell: spack-bash {0}
         env:
           GITHUB_USER: ${{github.actor}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: spack --env . buildcache push --update-index local-buildcache
+        run: |
+          spack env activate .
+          spack buildcache push --fail-fast --update-index --without-build-dependencies local-buildcache
         if: ${{!cancelled()}}
       - name: Build DDC
         shell: spack-bash {0}

--- a/docker/doxygen/Dockerfile
+++ b/docker/doxygen/Dockerfile
@@ -42,7 +42,7 @@ USER ci:ci
 WORKDIR /data
 
 COPY spack-env /data/spack-env
-RUN git clone --branch v1.1.1 --depth 1 https://github.com/spack/spack.git \
+RUN git clone --branch v1.2.0 --depth 1 https://github.com/spack/spack.git \
  && . /data/spack/share/spack/setup-env.sh \
  && spack env create ddc /data/spack-env/spack-cpu.yaml \
  && spack --env ddc repo update \

--- a/docker/doxygen/spack-env/spack-cpu.yaml
+++ b/docker/doxygen/spack-env/spack-cpu.yaml
@@ -26,18 +26,17 @@ spack:
       require: 'openblas@0.3'
   repos:
     builtin:
-      tag: v2026.03.0
+      tag: v2026.06.0
   specs:
     - 'gcc@13'
     - 'cmake@4.2'
     - 'ginkgo@1.11'
-    - 'kokkos@5.0'
-    - 'kokkos-fft@1.0 host_backend=fftw-serial'
-    - 'kokkos-kernels@5.0'
+    - 'kokkos@5.1'
+    - 'kokkos-fft@1.1 host_backend=fftw-serial'
+    - 'kokkos-kernels@5.1'
     - 'lapack'
     - 'paraconf@1.0'
-    - 'pkgconfig'
-    - 'pdi@1.10.1:1.10'
+    - 'pdi@1.11'
   view:
     default:
       root: .spack-env/view

--- a/docker/latest/Dockerfile
+++ b/docker/latest/Dockerfile
@@ -106,7 +106,7 @@ USER ci:ci
 WORKDIR /data
 
 COPY spack-env /data/spack-env
-RUN git clone --branch v1.1.1 --depth 1 https://github.com/spack/spack.git \
+RUN git clone --branch v1.2.0 --depth 1 https://github.com/spack/spack.git \
  && . /data/spack/share/spack/setup-env.sh \
  && spack env create ddc /data/spack-env/spack-${BACKEND}.yaml \
  && spack --env ddc repo update \

--- a/docker/latest/spack-env/spack-cpu.yaml
+++ b/docker/latest/spack-env/spack-cpu.yaml
@@ -26,23 +26,22 @@ spack:
       require: 'openblas@0.3'
   repos:
     builtin:
-      tag: v2026.03.0
+      tag: v2026.06.0
   specs:
     - 'gcc@13'
     - 'benchmark@1.9 ~performance_counters'
     - 'cmake@4.2'
     - 'ginkgo@1.11'
     - 'googletest@1.17 +gmock'
-    - 'kokkos@5.0'
-    - 'kokkos-fft@1.0 host_backend=fftw-serial'
-    - 'kokkos-kernels@5.0'
+    - 'kokkos@5.1'
+    - 'kokkos-fft@1.1 host_backend=fftw-serial'
+    - 'kokkos-kernels@5.1'
     - 'lapack'
     - 'paraconf@1.0'
-    - 'pkgconfig'
-    - 'pdi@1.10.1:1.10'
-    - 'pdiplugin-decl-hdf5@1.10.1:1.10'
-    - 'pdiplugin-user-code@1.10.1:1.10'
-    - 'pdiplugin-trace@1.10.1:1.10'
+    - 'pdi@1.11'
+    - 'pdiplugin-decl-hdf5@1.11'
+    - 'pdiplugin-user-code@1.11'
+    - 'pdiplugin-trace@1.11'
     - 'py-gcovr@8.6'
     - 'py-numpy@2.4'
     - 'py-pytest@9.0'

--- a/docker/latest/spack-env/spack-cuda.yaml
+++ b/docker/latest/spack-env/spack-cuda.yaml
@@ -31,23 +31,22 @@ spack:
       require: 'openblas@0.3'
   repos:
     builtin:
-      tag: v2026.03.0
+      tag: v2026.06.0
   specs:
     - 'gcc@12'
     - 'benchmark@1.9 ~performance_counters'
     - 'cmake@4.2'
     - 'ginkgo@1.11'
     - 'googletest@1.17 +gmock'
-    - 'kokkos@5.0 +cuda_constexpr +cuda_relocatable_device_code'
-    - 'kokkos-fft@1.0 host_backend=fftw-serial device_backend=cufft'
-    - 'kokkos-kernels@5.0'
+    - 'kokkos@5.1 +cuda_constexpr +cuda_relocatable_device_code'
+    - 'kokkos-fft@1.1 host_backend=fftw-serial device_backend=cufft'
+    - 'kokkos-kernels@5.1'
     - 'lapack'
     - 'paraconf@1.0'
-    - 'pkgconfig'
-    - 'pdi@1.10.1:1.10'
-    - 'pdiplugin-decl-hdf5@1.10.1:1.10'
-    - 'pdiplugin-user-code@1.10.1:1.10'
-    - 'pdiplugin-trace@1.10.1:1.10'
+    - 'pdi@1.11'
+    - 'pdiplugin-decl-hdf5@1.11'
+    - 'pdiplugin-user-code@1.11'
+    - 'pdiplugin-trace@1.11'
   view:
     default:
       root: .spack-env/view

--- a/docker/latest/spack-env/spack-hip.yaml
+++ b/docker/latest/spack-env/spack-hip.yaml
@@ -108,23 +108,22 @@ spack:
           spec: roctracer-dev@6.4.3
   repos:
     builtin:
-      tag: v2026.03.0
+      tag: v2026.06.0
   specs:
     - 'gcc@13'
     - 'benchmark@1.9 ~performance_counters'
     - 'cmake@4.2'
     - 'ginkgo@1.11 +rocm amdgpu_target=gfx90a'
     - 'googletest@1.17 +gmock'
-    - 'kokkos@5.0 +hip_relocatable_device_code +rocm amdgpu_target=gfx90a'
-    - 'kokkos-fft@1.0 host_backend=fftw-serial device_backend=hipfft'
-    - 'kokkos-kernels@5.0'
+    - 'kokkos@5.1 +hip_relocatable_device_code +rocm amdgpu_target=gfx90a'
+    - 'kokkos-fft@1.1 host_backend=fftw-serial device_backend=hipfft'
+    - 'kokkos-kernels@5.1'
     - 'lapack'
     - 'paraconf@1.0'
-    - 'pkgconfig'
-    - 'pdi@1.10.1:1.10'
-    - 'pdiplugin-decl-hdf5@1.10.1:1.10'
-    - 'pdiplugin-user-code@1.10.1:1.10'
-    - 'pdiplugin-trace@1.10.1:1.10'
+    - 'pdi@1.11'
+    - 'pdiplugin-decl-hdf5@1.11'
+    - 'pdiplugin-user-code@1.11'
+    - 'pdiplugin-trace@1.11'
   view:
     default:
       root: .spack-env/view

--- a/docker/oldest/Dockerfile
+++ b/docker/oldest/Dockerfile
@@ -101,11 +101,11 @@ USER ci:ci
 WORKDIR /data
 
 COPY spack-env /data/spack-env
-RUN git clone --branch v1.1.1 --depth 1 https://github.com/spack/spack.git \
+RUN git clone --branch v1.2.0 --depth 1 https://github.com/spack/spack.git \
  && . /data/spack/share/spack/setup-env.sh \
  && spack env create ddc /data/spack-env/spack-${BACKEND}.yaml \
  && spack --env ddc repo update \
- && spack --env ddc install --fail-fast
+ && spack --env ddc install --deprecated --fail-fast
 
 ENTRYPOINT ["/bin/bash_run.sh"]
 CMD ["/bin/bash", "-li"]

--- a/docker/oldest/spack-env/spack-cpu.yaml
+++ b/docker/oldest/spack-env/spack-cpu.yaml
@@ -26,7 +26,7 @@ spack:
       require: 'openblas@0.3'
   repos:
     builtin:
-      tag: v2026.03.0
+      tag: v2026.06.0
   specs:
     - 'gcc@11'
     - 'benchmark@1.9 ~performance_counters'
@@ -38,7 +38,6 @@ spack:
     - 'kokkos-kernels@4.7'
     - 'lapack'
     - 'paraconf@1.0'
-    - 'pkgconfig'
     - 'pdi@1.10.1:1.10'
     - 'pdiplugin-decl-hdf5@1.10.1:1.10'
     - 'pdiplugin-user-code@1.10.1:1.10'

--- a/docker/oldest/spack-env/spack-cuda.yaml
+++ b/docker/oldest/spack-env/spack-cuda.yaml
@@ -31,7 +31,7 @@ spack:
       require: 'openblas@0.3'
   repos:
     builtin:
-      tag: v2026.03.0
+      tag: v2026.06.0
   specs:
     - 'gcc@11'
     - 'benchmark@1.9 ~performance_counters'
@@ -43,7 +43,6 @@ spack:
     - 'kokkos-kernels@4.7'
     - 'lapack'
     - 'paraconf@1.0'
-    - 'pkgconfig'
     - 'pdi@1.10.1:1.10'
     - 'pdiplugin-decl-hdf5@1.10.1:1.10'
     - 'pdiplugin-user-code@1.10.1:1.10'

--- a/docker/oldest/spack-env/spack-hip.yaml
+++ b/docker/oldest/spack-env/spack-hip.yaml
@@ -108,7 +108,7 @@ spack:
           spec: roctracer-dev@6.2.4
   repos:
     builtin:
-      tag: v2026.03.0
+      tag: v2026.06.0
   specs:
     - 'gcc@11'
     - 'benchmark@1.9 ~performance_counters'
@@ -120,7 +120,6 @@ spack:
     - 'kokkos-kernels@4.7'
     - 'lapack'
     - 'paraconf@1.0'
-    - 'pkgconfig'
     - 'pdi@1.10.1:1.10'
     - 'pdiplugin-decl-hdf5@1.10.1:1.10'
     - 'pdiplugin-user-code@1.10.1:1.10'

--- a/spack-env/spack-macos-14.yaml
+++ b/spack-env/spack-macos-14.yaml
@@ -37,23 +37,22 @@ spack:
       require: 'openblas@0.3'
   repos:
     builtin:
-      tag: v2026.03.0
+      tag: v2026.06.0
   specs:
     - 'apple-clang@15.0'
     - 'benchmark@1.9 ~performance_counters'
     - 'cmake@4.2'
     - 'ginkgo@1.11'
     - 'googletest@1.17 +gmock'
-    - 'kokkos@5.0'
-    - 'kokkos-fft@1.0 host_backend=fftw-serial'
-    - 'kokkos-kernels@5.0'
+    - 'kokkos@5.1'
+    - 'kokkos-fft@1.1 host_backend=fftw-serial'
+    - 'kokkos-kernels@5.1'
     - 'lapack'
     - 'paraconf@1.0'
-    - 'pkgconfig'
-    - 'pdi@1.10.1:1.10 ~python'
-    - 'pdiplugin-decl-hdf5@1.10.1:1.10'
-    - 'pdiplugin-user-code@1.10.1:1.10'
-    - 'pdiplugin-trace@1.10.1:1.10'
+    - 'pdi@1.11'
+    - 'pdiplugin-decl-hdf5@1.11'
+    - 'pdiplugin-user-code@1.11'
+    - 'pdiplugin-trace@1.11'
   view:
     default:
       root: .spack-env/view

--- a/spack-env/spack-macos-15.yaml
+++ b/spack-env/spack-macos-15.yaml
@@ -37,23 +37,22 @@ spack:
       require: 'openblas@0.3'
   repos:
     builtin:
-      tag: v2026.03.0
+      tag: v2026.06.0
   specs:
     - 'apple-clang@17'
     - 'benchmark@1.9 ~performance_counters'
     - 'cmake@4.2'
     - 'ginkgo@1.11'
     - 'googletest@1.17 +gmock'
-    - 'kokkos@5.0'
-    - 'kokkos-fft@1.0 host_backend=fftw-serial'
-    - 'kokkos-kernels@5.0'
+    - 'kokkos@5.1'
+    - 'kokkos-fft@1.1 host_backend=fftw-serial'
+    - 'kokkos-kernels@5.1'
     - 'lapack'
     - 'paraconf@1.0'
-    - 'pkgconfig'
-    - 'pdi@1.10.1:1.10 ~python'
-    - 'pdiplugin-decl-hdf5@1.10.1:1.10'
-    - 'pdiplugin-user-code@1.10.1:1.10'
-    - 'pdiplugin-trace@1.10.1:1.10'
+    - 'pdi@1.11'
+    - 'pdiplugin-decl-hdf5@1.11'
+    - 'pdiplugin-user-code@1.11'
+    - 'pdiplugin-trace@1.11'
   view:
     default:
       root: .spack-env/view


### PR DESCRIPTION
- Use Spack 1.2.0 with packages v2026.06.0.
- Update `latest` environments
- Fix Spack error when pushing by adding `--without-build-dependencies`.
- Remove explicit `pkgconfig` dependency, PDI fixed its dependency.
