### PR TITLE
Add tolerance to assertions

### DIFF
--- a/src/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/src/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -513,8 +513,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
-    KOKKOS_ASSERT(ddc::coordinate(icell) <= x)
-    KOKKOS_ASSERT(ddc::coordinate(icell + 1) >= x)
+    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 1e-14)
+    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 1e-14)
 
     // 2. Compute values of derivatives of B-splines with support over cell 'icell'
 
@@ -586,8 +586,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
-    KOKKOS_ASSERT(ddc::coordinate(icell) <= x)
-    KOKKOS_ASSERT(ddc::coordinate(icell + 1) >= x)
+    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 1e-14)
+    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 1e-14)
 
     // 2. Compute nonzero basis functions and knot differences for splines
     //    up to degree (degree-1) which are needed to compute derivative


### PR DESCRIPTION
Add tolerance to assertions in `NonUniformBSplines::eval_deriv` and `NonUniformBSplines::eval_basis_and_n_derivs` to fix #1191 