### PR TITLE
Fix 2D extrapolation rule usage in SplineEvaluatorND

### DIFF
--- a/src/ddc/kernels/splines/spline_evaluator_nd.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator_nd.hpp
@@ -152,6 +152,17 @@ private:
     cexa::tuple<ddc::type_seq_element_t<s_idx<BSplines>, upper_extrap_rule_ts>...>
             m_upper_extrap_rules;
 
+    /**
+     * @brief Build a SplineEvaluatorND acting on batched_spline_domain.
+     *
+     * @param extrap_rules The extrapolation rules at the lower then upper boundary, for each dimension.
+     */
+    explicit SplineEvaluatorND(cexa::tuple<ExtrapolationRule...> const& extrap_rules)
+        : m_lower_extrap_rules(cexa::get<2 * s_idx<BSplines>>(extrap_rules)...)
+        , m_upper_extrap_rules(cexa::get<2 * s_idx<BSplines> + 1>(extrap_rules)...)
+    {
+    }
+
 public:
     static_assert(
             sizeof...(BSplines) == dimension,
@@ -182,10 +193,10 @@ public:
             (std::is_invocable_r_v<
                      double,
                      ddc::type_seq_element_t<s_idx<BSplines>, lower_extrap_rule_ts>,
-                     ddc::Coordinate<typename BSplines::continuous_dimension_type>,
+                     ddc::Coordinate<typename BSplines::continuous_dimension_type...>,
                      ddc::ChunkSpan<
                              double const,
-                             ddc::DiscreteDomain<BSplines>,
+                             ddc::DiscreteDomain<BSplines...>,
                              Kokkos::layout_right,
                              memory_space>>
              && ...),
@@ -195,10 +206,10 @@ public:
             (std::is_invocable_r_v<
                      double,
                      ddc::type_seq_element_t<s_idx<BSplines>, upper_extrap_rule_ts>,
-                     ddc::Coordinate<typename BSplines::continuous_dimension_type>,
+                     ddc::Coordinate<typename BSplines::continuous_dimension_type...>,
                      ddc::ChunkSpan<
                              double const,
-                             ddc::DiscreteDomain<BSplines>,
+                             ddc::DiscreteDomain<BSplines...>,
                              Kokkos::layout_right,
                              memory_space>>
              && ...),
@@ -212,19 +223,9 @@ public:
      *
      * @see NullExtrapolationRule ConstantExtrapolationRule PeriodicExtrapolationRule
      */
-    template <class... ExtrapRules>
-    explicit SplineEvaluatorND(ExtrapRules const&... extrap_rules)
+    explicit SplineEvaluatorND(ExtrapolationRule const&... extrap_rules)
+        : SplineEvaluatorND(cexa::make_tuple(extrap_rules...))
     {
-        static_assert(
-                (std::is_same_v<ExtrapRules, ExtrapolationRule> && ...),
-                "The type of the extrapolation rules passed to the constructor should be the same "
-                "as the ones passed as template argument to the class");
-
-        cexa::tuple<ExtrapRules...> extrap_rules_tuple(extrap_rules...);
-        m_lower_extrap_rules
-                = cexa::make_tuple(cexa::get<2 * s_idx<BSplines>>(extrap_rules_tuple)...);
-        m_upper_extrap_rules
-                = cexa::make_tuple(cexa::get<2 * s_idx<BSplines> + 1>(extrap_rules_tuple)...);
     }
 
     /**

--- a/tests/splines/CMakeLists.txt
+++ b/tests/splines/CMakeLists.txt
@@ -83,26 +83,34 @@ foreach(bc "periodic" "greville")
     foreach(degree RANGE "${DDC_SPLINES_TEST_DEGREE_MIN}" "${DDC_SPLINES_TEST_DEGREE_MAX}")
         foreach(bsplines_type "uniform" "non_uniform")
             foreach(er "null" "constant")
-                string(TOUPPER "bc_${bc}" bc_macro)
-                string(TOUPPER "degree=${degree}" degree_macro)
-                string(TOUPPER "bsplines_type_${bsplines_type}" bsplines_type_macro)
-                string(TOUPPER "er_${er}" er_macro)
-                set(test_filename "extrapolation_rule")
-                set(test_name
-                    "${test_filename}_tests_degree_${degree}_${bsplines_type}_${bc}_${er}"
-                )
+                foreach(evaluator_class "2d" "nd")
+                    string(TOUPPER "bc_${bc}" bc_macro)
+                    string(TOUPPER "degree=${degree}" degree_macro)
+                    string(TOUPPER "bsplines_type_${bsplines_type}" bsplines_type_macro)
+                    string(TOUPPER "er_${er}" er_macro)
+                    string(TOUPPER "evaluator_class_${evaluator_class}" evaluator_class_macro)
+                    set(test_filename "extrapolation_rule")
+                    set(test_name
+                        "${test_filename}_tests_degree_${degree}_${bsplines_type}_${bc}_${er}_evaluator_${evaluator_class}"
+                    )
 
-                add_executable("${test_name}" "${test_filename}.cpp")
-                target_compile_definitions(
-                    "${test_name}"
-                    PRIVATE -D${bc_macro} -D${degree_macro} -D${bsplines_type_macro} -D${er_macro}
-                )
-                target_compile_features("${test_name}" PRIVATE cxx_std_20)
-                target_link_libraries(
-                    "${test_name}"
-                    PRIVATE ddc_gtest_main DDC::core DDC::splines GTest::gtest
-                )
-                gtest_discover_tests("${test_name}" DISCOVERY_MODE PRE_TEST)
+                    add_executable("${test_name}" "${test_filename}.cpp")
+                    target_compile_definitions(
+                        "${test_name}"
+                        PRIVATE
+                            -D${bc_macro}
+                            -D${degree_macro}
+                            -D${bsplines_type_macro}
+                            -D${er_macro}
+                            -D${evaluator_class_macro}
+                    )
+                    target_compile_features("${test_name}" PRIVATE cxx_std_20)
+                    target_link_libraries(
+                        "${test_name}"
+                        PRIVATE ddc_gtest_main DDC::core DDC::splines GTest::gtest
+                    )
+                    gtest_discover_tests("${test_name}" DISCOVERY_MODE PRE_TEST)
+                endforeach()
             endforeach()
         endforeach()
     endforeach()

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -255,17 +255,16 @@ void TestExtrapolationRuleSpline()
 #    endif
 #endif
 
-    ddc::SplineEvaluator2D<
+    ddc::SplineEvaluatorND<
             ExecSpace,
             MemorySpace,
-            BSplines<I1>,
-            BSplines<I2>,
-            DDimI1,
-            DDimI2,
-            extrapolation_rule_dim_1_type,
-            extrapolation_rule_dim_1_type,
-            extrapolation_rule_dim_2_type,
-            extrapolation_rule_dim_2_type> const
+            ddc::detail::TypeSeq<BSplines<I1>, BSplines<I2>>,
+            ddc::detail::TypeSeq<DDimI1, DDimI2>,
+            ddc::detail::TypeSeq<
+                    extrapolation_rule_dim_1_type,
+                    extrapolation_rule_dim_1_type,
+                    extrapolation_rule_dim_2_type,
+                    extrapolation_rule_dim_2_type>> const
             spline_evaluator_batched(
                     extrapolation_rule_left_dim_1,
                     extrapolation_rule_right_dim_1,

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -255,6 +255,24 @@ void TestExtrapolationRuleSpline()
 #    endif
 #endif
 
+#if defined(EVALUATOR_CLASS_2D)
+    ddc::SplineEvaluator2D<
+            ExecSpace,
+            MemorySpace,
+            BSplines<I1>,
+            BSplines<I2>,
+            DDimI1,
+            DDimI2,
+            extrapolation_rule_dim_1_type,
+            extrapolation_rule_dim_1_type,
+            extrapolation_rule_dim_2_type,
+            extrapolation_rule_dim_2_type> const
+            spline_evaluator_batched(
+                    extrapolation_rule_left_dim_1,
+                    extrapolation_rule_right_dim_1,
+                    extrapolation_rule_left_dim_2,
+                    extrapolation_rule_right_dim_2);
+#elif defined(EVALUATOR_CLASS_ND)
     ddc::SplineEvaluatorND<
             ExecSpace,
             MemorySpace,
@@ -270,6 +288,7 @@ void TestExtrapolationRuleSpline()
                     extrapolation_rule_right_dim_1,
                     extrapolation_rule_left_dim_2,
                     extrapolation_rule_right_dim_2);
+#endif
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<I1, I2>, MemorySpace>());


### PR DESCRIPTION
This aims to fix both:
- wrong static assertion
- implicit usage of the default constructor of the extrapolation rule (ddc::ConstantExtrapolationRule does not have a default constructor)

It also removes unnecessary variadic templates on the constructor of SplineEvaluatorND.