### PR TITLE
Test extrapolation rules with both the 2D and ND evaluators

### DIFF
--- a/tests/splines/CMakeLists.txt
+++ b/tests/splines/CMakeLists.txt
@@ -83,26 +83,34 @@ foreach(bc "periodic" "greville")
     foreach(degree RANGE "${DDC_SPLINES_TEST_DEGREE_MIN}" "${DDC_SPLINES_TEST_DEGREE_MAX}")
         foreach(bsplines_type "uniform" "non_uniform")
             foreach(er "null" "constant")
-                string(TOUPPER "bc_${bc}" bc_macro)
-                string(TOUPPER "degree=${degree}" degree_macro)
-                string(TOUPPER "bsplines_type_${bsplines_type}" bsplines_type_macro)
-                string(TOUPPER "er_${er}" er_macro)
-                set(test_filename "extrapolation_rule")
-                set(test_name
-                    "${test_filename}_tests_degree_${degree}_${bsplines_type}_${bc}_${er}"
-                )
+                foreach(evaluator_class "2d" "nd")
+                    string(TOUPPER "bc_${bc}" bc_macro)
+                    string(TOUPPER "degree=${degree}" degree_macro)
+                    string(TOUPPER "bsplines_type_${bsplines_type}" bsplines_type_macro)
+                    string(TOUPPER "er_${er}" er_macro)
+                    string(TOUPPER "evaluator_class_${evaluator_class}" evaluator_class_macro)
+                    set(test_filename "extrapolation_rule")
+                    set(test_name
+                        "${test_filename}_tests_degree_${degree}_${bsplines_type}_${bc}_${er}_evaluator_${evaluator_class}"
+                    )
 
-                add_executable("${test_name}" "${test_filename}.cpp")
-                target_compile_definitions(
-                    "${test_name}"
-                    PRIVATE -D${bc_macro} -D${degree_macro} -D${bsplines_type_macro} -D${er_macro}
-                )
-                target_compile_features("${test_name}" PRIVATE cxx_std_20)
-                target_link_libraries(
-                    "${test_name}"
-                    PRIVATE ddc_gtest_main DDC::core DDC::splines GTest::gtest
-                )
-                gtest_discover_tests("${test_name}" DISCOVERY_MODE PRE_TEST)
+                    add_executable("${test_name}" "${test_filename}.cpp")
+                    target_compile_definitions(
+                        "${test_name}"
+                        PRIVATE
+                            -D${bc_macro}
+                            -D${degree_macro}
+                            -D${bsplines_type_macro}
+                            -D${er_macro}
+                            -D${evaluator_class_macro}
+                    )
+                    target_compile_features("${test_name}" PRIVATE cxx_std_20)
+                    target_link_libraries(
+                        "${test_name}"
+                        PRIVATE ddc_gtest_main DDC::core DDC::splines GTest::gtest
+                    )
+                    gtest_discover_tests("${test_name}" DISCOVERY_MODE PRE_TEST)
+                endforeach()
             endforeach()
         endforeach()
     endforeach()

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -255,6 +255,24 @@ void TestExtrapolationRuleSpline()
 #    endif
 #endif
 
+#if defined(EVALUATOR_CLASS_2D)
+    ddc::SplineEvaluator2D<
+            ExecSpace,
+            MemorySpace,
+            BSplines<I1>,
+            BSplines<I2>,
+            DDimI1,
+            DDimI2,
+            extrapolation_rule_dim_1_type,
+            extrapolation_rule_dim_1_type,
+            extrapolation_rule_dim_2_type,
+            extrapolation_rule_dim_2_type> const
+            spline_evaluator_batched(
+                    extrapolation_rule_left_dim_1,
+                    extrapolation_rule_right_dim_1,
+                    extrapolation_rule_left_dim_2,
+                    extrapolation_rule_right_dim_2);
+#elif defined(EVALUATOR_CLASS_ND)
     ddc::SplineEvaluatorND<
             ExecSpace,
             MemorySpace,
@@ -270,6 +288,7 @@ void TestExtrapolationRuleSpline()
                     extrapolation_rule_right_dim_1,
                     extrapolation_rule_left_dim_2,
                     extrapolation_rule_right_dim_2);
+#endif
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<I1, I2>, MemorySpace>());


### PR DESCRIPTION
Builds on top of #1210 and duplicates the extrapolation rule spline test to keep coverage for the 2D evaluator